### PR TITLE
docs: correct install/model setup to match reality

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -15,7 +15,7 @@ java -version
 
 Download the latest release from GitHub:
 
-1. Go to [Releases](https://github.com/krokozyab/claude-codex-orchestrator/releases)
+1. Go to [Releases](https://github.com/krokozyab/Agent-Fusion/releases)
 2. Download `release.zip` from the latest release
 3. Save it to your preferred location
 
@@ -43,7 +43,18 @@ watch_paths = [
 ```
 Other options you can configure later
 
-### 4. Start the Orchestrator
+### 4. (Optional) Embedding Model
+
+Semantic search uses a local ONNX embedding model. The default model
+(`all-MiniLM-L6-v2`, 384-dimensional) **and its vocabulary are bundled inside the JAR** —
+nothing to download, it works out of the box.
+
+To use a larger, higher-quality model (e.g. `baai-bge-base-en-v1.5`, 768-dimensional) at the
+cost of slower indexing, see [`docs/other_model.md`](other_model.md). Note for macOS users:
+do not place a custom model in `~/Downloads`, `~/Desktop`, or `~/Documents` — those folders are
+privacy-protected and model load will fail with `ORT_FAIL ... system error number 1`.
+
+### 5. Start the Orchestrator
 
 **Mac/Linux:**
 ```bash
@@ -53,7 +64,7 @@ Other options you can configure later
 Or double-click `start.sh` in Finder
 
 
-### 5. Verify It's Running
+### 6. Verify It's Running
 
 You will see index process started in terminal
 ater it finishes index all files it automatically open

--- a/docs/other_model.md
+++ b/docs/other_model.md
@@ -8,11 +8,15 @@ When you want higher-quality search at the cost of slower indexing, you can poin
 
 1. Download the ONNX file from Hugging Face: https://huggingface.co/LightEmbed/baai-bge-base-en-v1.5-onnx/blob/main/model.onnx.
 2. Place the downloaded file in a directory that the orchestrator can read (for example, `data/models/baai-bge-base-en-v1.5-onnx/model.onnx`).
+
+   > **macOS:** do **not** keep the model in `~/Downloads`, `~/Desktop`, or `~/Documents`. These are privacy-protected (TCC), and the JVM can see the file's size but is denied reading its contents, so model load fails with `ai.onnxruntime.OrtException: ORT_FAIL ... Load model ... failed: system error number 1`. Move it to a non-protected folder (e.g. `~/fusion-models/` or a path inside the project), and clear the download quarantine flag if needed: `xattr -d com.apple.quarantine <model.onnx>`.
 3. Open `fusionagent.toml` and update the `[context.embedding]` section:
    - Set `model_path` to the absolute path of the downloaded model.
    - Set `model = "baai-bge-base-en-v1.5-onnx"`.
-   - Set `embedding_dim = 768` to match the selected model.
+   - Set `dimension = 768` to match the selected model. (The config key is `dimension`; it defaults to 384. A wrong or missing value causes an "Embedding dimension mismatch" error at index time.)
 4. Delete the existing `context.duckdb` (and `context.duckdb.wal` if present) so the index rebuilds with the new embedding size.
 5. Restart the orchestrator (e.g., `./start.sh`) so it loads the new configuration and reindexes your files.
 
-Once the restart completes, the context indexer will ingest documents with the new embedding model. Expect improved semantic recall but longer ingestion times relative to the default `all-MiniLM-L6-v2.onnx`.
+The bundled WordPiece vocabulary (`vocab.txt`, bert-base-uncased) is shared by both the default `all-MiniLM-L6-v2` and `baai-bge-base-en-v1.5`, so switching between them needs no vocabulary change.
+
+Once the restart completes, the context indexer will ingest documents with the new embedding model. Expect improved semantic recall but longer ingestion times relative to the default `all-MiniLM-L6-v2.onnx` (the larger model is several times slower per embedding on CPU).


### PR DESCRIPTION
Fixes doc/reality mismatches found while debugging a real bge-base setup.

- **other_model.md**: config key is `dimension`, not `embedding_dim` (loader reads `dimension`, defaults to 384 → "Embedding dimension mismatch" against a 768-dim model). Added a macOS TCC warning (models in Downloads/Desktop/Documents fail with `ORT_FAIL ... system error number 1`) and a note that the bundled `vocab.txt` is shared by MiniLM and bge-base.
- **INSTALL.md**: fixed stale releases URL (`claude-codex-orchestrator` → `Agent-Fusion`); added a short embedding-model step (default model + vocab are bundled; link to other_model.md; macOS protected-folder caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)