### PR TITLE
chunking: handle Oracle PL/SQL in SqlChunker

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/chunking/ChunkerRegistry.kt
+++ b/src/main/kotlin/com/orchestrator/context/chunking/ChunkerRegistry.kt
@@ -46,7 +46,18 @@ class ConfigurableChunkerRegistry(
         "docx" to WordChunker(overlapPercent = overlapPercent),
         "pdf" to PdfChunker(overlapPercent = overlapPercent),
         "json" to CachingSimpleChunkerAdapter { JsonChunker(overlapPercent = overlapPercent) },
-        "sql" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) }
+        "sql" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        // Oracle PL/SQL source file extensions (package spec/body, procedures, functions, triggers,
+        // types) — route them to SqlChunker instead of the plain-text fallback.
+        "pls" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "plsql" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "pks" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "pkb" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "prc" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "fnc" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "trg" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "tps" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) },
+        "tpb" to CachingSimpleChunkerAdapter { SqlChunker(overlapPercent = overlapPercent) }
     )
 
     override fun getChunker(filePath: Path): Chunker {

--- a/src/main/kotlin/com/orchestrator/context/chunking/SqlChunker.kt
+++ b/src/main/kotlin/com/orchestrator/context/chunking/SqlChunker.kt
@@ -10,9 +10,29 @@ class SqlChunker(
     private val overlapPercent: Int = 15
 ) : SimpleChunker {
 
-    private val routineStartRegex = Regex("""\bCREATE\s+(?:FUNCTION|PROCEDURE|TRIGGER)\b""", RegexOption.IGNORE_CASE)
+    // A PL/SQL routine start. Crucially tolerates `OR REPLACE` and `[NON]EDITIONABLE` (which sit
+    // between CREATE and the object keyword in virtually all real Oracle DDL) and adds PACKAGE [BODY]
+    // and TYPE [BODY]. The previous `CREATE\s+(FUNCTION|PROCEDURE|TRIGGER)` never matched
+    // `CREATE OR REPLACE PROCEDURE ...`, so Oracle bodies were split on every internal `;`.
+    private val routineStartRegex = Regex(
+        """\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:(?:NON)?EDITIONABLE\s+)?(?:PACKAGE(?:\s+BODY)?|TYPE(?:\s+BODY)?|PROCEDURE|FUNCTION|TRIGGER)\b""",
+        RegexOption.IGNORE_CASE
+    )
+    // PACKAGE/TYPE [BODY] need different termination: their inner sub-program ENDs return depth to 0
+    // while still inside the package, so the `;`+END heuristic mis-fires. These terminate only on the
+    // SQL*Plus `/` (or EOF).
+    private val packageStartRegex = Regex(
+        """\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:(?:NON)?EDITIONABLE\s+)?(?:PACKAGE|TYPE)\b""",
+        RegexOption.IGNORE_CASE
+    )
+    // Anonymous PL/SQL block opener (script-style `DECLARE ...` / bare `BEGIN ...`). A `BEGIN` that
+    // ends with `;` on the same line is a transaction-control statement, not a block, so the caller
+    // guards on that.
+    private val anonBlockStartRegex = Regex("""^(?:DECLARE|BEGIN)\b""", RegexOption.IGNORE_CASE)
     private val beginRegex = Regex("""\bBEGIN\b""", RegexOption.IGNORE_CASE)
-    private val endRegex = Regex("""\bEND\b""", RegexOption.IGNORE_CASE)
+    // A block-closing END. Excludes `END IF` / `END LOOP` / `END CASE`, which close control
+    // structures (no matching BEGIN) and would otherwise drive the nesting depth negative.
+    private val blockEndRegex = Regex("""\bEND\b(?!\s+(?:IF|LOOP|CASE)\b)""", RegexOption.IGNORE_CASE)
     
     /** A SQL statement together with its 1-based inclusive line span in the source file. */
     private data class SqlStatement(val text: String, val startLine: Int, val endLine: Int)
@@ -42,11 +62,21 @@ class SqlChunker(
         val pendingComments = StringBuilder()
         var insideRoutine = false
         var routineDepth = 0
+        var routineIsPackage = false
         // Track the source line span of the statement being assembled. `stmtStartLine` is the first
         // line that contributes to it (leading comment or code); `pendingStartLine` anchors comments
         // that may precede the code. Both are 1-based; -1 means "not set yet".
         var stmtStartLine = -1
         var pendingStartLine = -1
+        // 1-based line number of the last line actually appended to currentStatement, so a `/`
+        // terminator (which is itself dropped) can close the statement at the real last content line.
+        var lastAppendedLine = -1
+
+        fun resetRoutineState() {
+            insideRoutine = false
+            routineDepth = 0
+            routineIsPackage = false
+        }
 
         lines.forEachIndexed { index, line ->
             val lineNumber = index + 1
@@ -79,6 +109,23 @@ class SqlChunker(
                 return@forEachIndexed
             }
 
+            // SQL*Plus slash terminator: a line containing only `/` ends the current PL/SQL block
+            // (the canonical, unambiguous terminator for packages/types/anonymous blocks). The `/`
+            // itself is a directive, not part of the object, so it is dropped from the chunk.
+            if (trimmed == "/") {
+                if (currentStatement.isNotEmpty()) {
+                    val start = if (stmtStartLine != -1) stmtStartLine else lineNumber
+                    val end = if (lastAppendedLine != -1) lastAppendedLine else lineNumber
+                    statements.add(SqlStatement(currentStatement.toString().trim(), start, end.coerceAtLeast(start)))
+                    currentStatement.setLength(0)
+                    pendingComments.setLength(0)
+                    stmtStartLine = -1
+                    pendingStartLine = -1
+                    resetRoutineState()
+                }
+                return@forEachIndexed
+            }
+
             // Skip empty lines between statements
             if (trimmed.isEmpty() && currentStatement.isEmpty()) {
                 return@forEachIndexed
@@ -94,26 +141,40 @@ class SqlChunker(
             if (stmtStartLine == -1) stmtStartLine = lineNumber
 
             currentStatement.append(line).append("\n")
+            lastAppendedLine = lineNumber
 
-            if (!insideRoutine && routineStartRegex.containsMatchIn(upperTrimmed)) {
-                insideRoutine = true
-                routineDepth = 0
+            val lineEndsWithSemicolon = line.trimEnd().endsWith(";")
+
+            if (!insideRoutine) {
+                if (routineStartRegex.containsMatchIn(upperTrimmed)) {
+                    insideRoutine = true
+                    routineDepth = 0
+                    routineIsPackage = packageStartRegex.containsMatchIn(upperTrimmed)
+                } else if (anonBlockStartRegex.containsMatchIn(upperTrimmed) && !lineEndsWithSemicolon) {
+                    // Anonymous block (DECLARE.../BEGIN...). A `BEGIN;` is transaction control, not a
+                    // block, and is excluded by the !endsWithSemicolon guard.
+                    insideRoutine = true
+                    routineDepth = 0
+                    routineIsPackage = false
+                }
             }
 
             if (insideRoutine) {
                 if (beginRegex.containsMatchIn(upperTrimmed)) {
                     routineDepth += 1
                 }
-                if (endRegex.containsMatchIn(upperTrimmed)) {
+                if (blockEndRegex.containsMatchIn(upperTrimmed)) {
                     routineDepth = (routineDepth - 1).coerceAtLeast(0)
                 }
             }
 
-            // Check for statement terminator
-            val lineEndsWithSemicolon = line.trimEnd().endsWith(";")
+            // Check for statement terminator.
             val shouldTerminate = when {
                 !insideRoutine -> lineEndsWithSemicolon
-                else -> lineEndsWithSemicolon && routineDepth == 0 && endRegex.containsMatchIn(upperTrimmed)
+                // Packages/types terminate only on `/` (handled above) or EOF: their inner ENDs
+                // legitimately return depth to 0 while still inside the package.
+                routineIsPackage -> false
+                else -> lineEndsWithSemicolon && routineDepth == 0 && blockEndRegex.containsMatchIn(upperTrimmed)
             }
 
             if (shouldTerminate) {
@@ -122,10 +183,7 @@ class SqlChunker(
                 pendingComments.setLength(0)
                 stmtStartLine = -1
                 pendingStartLine = -1
-                if (insideRoutine) {
-                    insideRoutine = false
-                    routineDepth = 0
-                }
+                resetRoutineState()
             }
         }
 
@@ -145,6 +203,20 @@ class SqlChunker(
             .replace(Regex("--.*"), "")
             .trim()
         
+        // PL/SQL CREATE with optional OR REPLACE / [NON]EDITIONABLE, incl. PACKAGE/TYPE [BODY].
+        // Handled first so `CREATE OR REPLACE PACKAGE BODY pkg` labels as "CREATE PACKAGE BODY pkg"
+        // rather than falling through to the first-word fallback. Oracle identifiers may contain
+        // `$`/`#` and may be quoted.
+        val plsqlCreate = Regex(
+            """^CREATE\s+(?:OR\s+REPLACE\s+)?(?:(?:NON)?EDITIONABLE\s+)?(PACKAGE\s+BODY|PACKAGE|TYPE\s+BODY|TYPE|PROCEDURE|FUNCTION|TRIGGER)\s+(?:IF\s+NOT\s+EXISTS\s+)?("?[\w$#.]+"?)""",
+            RegexOption.IGNORE_CASE
+        )
+        plsqlCreate.find(cleanStatement)?.let { m ->
+            val kind = m.groupValues[1].replace(Regex("\\s+"), " ").uppercase(Locale.US)
+            val name = m.groupValues[2].trim('"')
+            return "CREATE $kind $name"
+        }
+
         // Extract statement type and table/object name
         val patterns = listOf(
             Regex("""^(CREATE\s+(?:TABLE|VIEW|INDEX|PROCEDURE|FUNCTION|TRIGGER))\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)""", RegexOption.IGNORE_CASE),

--- a/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerOracleTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerOracleTest.kt
@@ -1,0 +1,129 @@
+package com.orchestrator.context.chunking
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Oracle PL/SQL coverage for SqlChunker (CREATE OR REPLACE, PACKAGE/TYPE, `/` terminator, END IF). */
+class SqlChunkerOracleTest {
+
+    private val chunker = SqlChunker(overlapPercent = 0)
+
+    @Test
+    fun `CREATE OR REPLACE PROCEDURE is one chunk despite internal semicolons and END IF`() {
+        val sql = """
+            CREATE OR REPLACE PROCEDURE adjust(p IN NUMBER) IS
+              v NUMBER;
+            BEGIN
+              v := p * 2;
+              IF v > 10 THEN
+                v := 10;
+              END IF;
+              UPDATE t SET c = v;
+            END adjust;
+            /
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "adjust.sql")
+
+        assertEquals(1, chunks.size, "the whole routine body must stay in one chunk")
+        val c = chunks.single()
+        assertEquals("CREATE PROCEDURE adjust", c.summary)
+        assertTrue(c.content.contains("END adjust"), "chunk must include the routine body")
+        assertEquals(1, c.startLine)
+        assertEquals(9, c.endLine, "ends at 'END adjust;' (line 9), the '/' directive is dropped")
+    }
+
+    @Test
+    fun `CREATE OR REPLACE PACKAGE BODY stays whole and terminates on slash`() {
+        val sql = """
+            CREATE OR REPLACE PACKAGE BODY pkg AS
+              PROCEDURE a IS BEGIN NULL; END a;
+              PROCEDURE b IS BEGIN NULL; END b;
+            END pkg;
+            /
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "pkg.pkb")
+
+        assertEquals(1, chunks.size, "a package body's inner procedure ENDs must not split it")
+        val c = chunks.single()
+        assertEquals("CREATE PACKAGE BODY pkg", c.summary)
+        assertTrue(c.content.contains("PROCEDURE a") && c.content.contains("PROCEDURE b"))
+        assertEquals(1, c.startLine)
+        assertEquals(4, c.endLine, "ends at 'END pkg;' (line 4); the '/' is dropped")
+    }
+
+    @Test
+    fun `anonymous DECLARE block is one chunk, not split on internal semicolons`() {
+        val sql = """
+            DECLARE
+              v NUMBER;
+            BEGIN
+              v := 1;
+              UPDATE t SET c = v;
+            END;
+            /
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "anon.sql")
+
+        assertEquals(1, chunks.size)
+        assertTrue(chunks.single().content.contains("DECLARE"))
+        assertTrue(chunks.single().content.contains("END;"))
+    }
+
+    @Test
+    fun `two slash-terminated routines split into two chunks`() {
+        val sql = """
+            CREATE OR REPLACE FUNCTION f RETURN NUMBER IS
+            BEGIN
+              RETURN 1;
+            END f;
+            /
+            CREATE OR REPLACE PROCEDURE p IS
+            BEGIN
+              NULL;
+            END p;
+            /
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "two.sql")
+
+        assertEquals(2, chunks.size)
+        assertEquals("CREATE FUNCTION f", chunks[0].summary)
+        assertEquals("CREATE PROCEDURE p", chunks[1].summary)
+    }
+
+    @Test
+    fun `transaction BEGIN is not treated as a PL-SQL block`() {
+        // Regression guard: `BEGIN;` ends with a semicolon → transaction control, three statements.
+        val sql = """
+            BEGIN;
+            INSERT INTO t VALUES (1);
+            COMMIT;
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "tx.sql")
+
+        assertEquals(3, chunks.size)
+        assertTrue(chunks.first().summary!!.contains("BEGIN"))
+    }
+
+    @Test
+    fun `labels CREATE OR REPLACE TRIGGER`() {
+        val sql = """
+            CREATE OR REPLACE TRIGGER trg_audit BEFORE INSERT ON t
+            FOR EACH ROW
+            BEGIN
+              NULL;
+            END;
+            /
+        """.trimIndent()
+
+        val chunk = chunker.chunk(sql, "trg.trg").firstOrNull()
+        assertNotNull(chunk)
+        assertEquals("CREATE TRIGGER trg_audit", chunk.summary)
+    }
+}


### PR DESCRIPTION
SqlChunker mishandled real Oracle PL/SQL. Fixes:

- routine-start regex tolerates `OR REPLACE` / `[NON]EDITIONABLE` and adds `PACKAGE [BODY]` / `TYPE [BODY]` (previously `CREATE OR REPLACE PROCEDURE ...` was never recognised → body split on every internal `;`);
- PACKAGE/TYPE terminate only on the SQL*Plus `/` or EOF (inner sub-program ENDs no longer split them);
- the `/` terminator is honoured and dropped from the chunk, with the real last-content line as the end line;
- block-close detection excludes `END IF/LOOP/CASE`;
- anonymous `DECLARE`/`BEGIN` blocks are recognised (a `BEGIN;` stays transaction control);
- proper labels for `CREATE OR REPLACE PACKAGE BODY` etc.;
- ChunkerRegistry routes `.pls/.plsql/.pks/.pkb/.prc/.fnc/.trg/.tps/.tpb` to SqlChunker instead of plain text.

6 new Oracle tests + existing 36 SqlChunker tests pass. Heuristic, not a parser: a package is one chunk (no per-procedure split) — that needs an AST/tree-sitter PL/SQL grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)