### PR TITLE
chunking: prototype tree-sitter-based Kotlin chunker (not wired in)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,11 @@ dependencies {
 
     // Java Parser for chunking
     implementation("com.github.javaparser:javaparser-core:3.25.7")
-    
+
+    // tree-sitter (AST-based chunking) — JNI binding (Java 11+) + Kotlin grammar
+    implementation("io.github.bonede:tree-sitter:0.25.3")
+    implementation("io.github.bonede:tree-sitter-kotlin:0.3.8.1")
+
     // YAML Parser for chunking
     implementation("org.yaml:snakeyaml:2.2")
     

--- a/src/main/kotlin/com/orchestrator/context/chunking/KotlinTreeSitterChunker.kt
+++ b/src/main/kotlin/com/orchestrator/context/chunking/KotlinTreeSitterChunker.kt
@@ -1,0 +1,123 @@
+package com.orchestrator.context.chunking
+
+import com.orchestrator.context.domain.Chunk
+import com.orchestrator.context.domain.ChunkKind
+import com.orchestrator.utils.Logger
+import org.treesitter.TSNode
+import org.treesitter.TSParser
+import org.treesitter.TSPoint
+import org.treesitter.TreeSitterKotlin
+import java.time.Instant
+
+/**
+ * Prototype: AST-based Kotlin chunker backed by tree-sitter.
+ *
+ * Splits a Kotlin file at top-level declarations using the real parse tree, so chunk boundaries and
+ * line ranges come from the grammar rather than the regex/brace heuristics in [KotlinChunker].
+ *
+ * Robustness notes (learned from the grammar's actual behaviour):
+ *  - The `tree-sitter-kotlin` grammar reports `hasError() == true` even on valid Kotlin, yet its
+ *    declaration nodes and line ranges are still correct. So we do NOT bail on `hasError()`; instead
+ *    we extract what we can and fall back to [fallback] only when parsing throws or yields nothing.
+ *  - tree-sitter byte offsets index the UTF-8 encoding, not Java chars — we slice the `ByteArray`.
+ *  - Parsers are not thread-safe; the registry wraps SimpleChunkers in a ThreadLocal adapter
+ *    (CachingSimpleChunkerAdapter), giving one parser per thread, which satisfies that requirement.
+ */
+class KotlinTreeSitterChunker(
+    private val maxTokens: Int = 600,
+    private val overlapPercent: Int = 15,
+    private val fallback: SimpleChunker = KotlinChunker(maxTokens, overlapPercent)
+) : SimpleChunker {
+
+    private val log = Logger.logger("com.orchestrator.context.chunking.KotlinTreeSitterChunker")
+
+    // One parser per instance; the registry's ThreadLocal adapter keeps it single-threaded.
+    private val parser: TSParser = TSParser().apply { setLanguage(TreeSitterKotlin()) }
+
+    override fun chunk(content: String, filePath: String): List<Chunk> {
+        if (content.isBlank()) return emptyList()
+
+        val root = runCatching { parser.parseString(null, content).rootNode }.getOrNull()
+        if (root == null || root.isNull) {
+            log.debug("tree-sitter parse unavailable for {} — falling back to heuristic chunker", filePath)
+            return fallback.chunk(content, filePath)
+        }
+
+        val bytes = content.toByteArray(Charsets.UTF_8)
+        val children = root.namedChildren()
+        val chunks = mutableListOf<Chunk>()
+        var ordinal = 0
+
+        // Header: package + imports collapsed into one CODE_HEADER chunk.
+        val headerNodes = children.filter { it.type == "package_header" || it.type == "import_list" }
+        if (headerNodes.isNotEmpty()) {
+            val start = headerNodes.first()
+            val end = headerNodes.last()
+            slice(bytes, start.startByte, end.endByte)?.let { text ->
+                buildChunk(text, ChunkKind.CODE_HEADER, ordinal++, lineOf(start.startPoint), endLineOf(end.endPoint))
+                    ?.let(chunks::add)
+            }
+        }
+
+        // Top-level declarations.
+        for (node in children) {
+            val kind = node.type.toChunkKind() ?: continue
+            slice(bytes, node.startByte, node.endByte)?.let { text ->
+                buildChunk(text, kind, ordinal++, lineOf(node.startPoint), endLineOf(node.endPoint))?.let(chunks::add)
+            }
+        }
+
+        if (chunks.isEmpty()) {
+            log.debug("tree-sitter produced no chunks for {} — falling back to heuristic chunker", filePath)
+            return fallback.chunk(content, filePath)
+        }
+
+        return OverlapProcessor.addOverlap(chunks, overlapPercent, ::estimateTokens)
+            .map { it.copy(tokenEstimate = (it.tokenEstimate ?: estimateTokens(it.content)).coerceAtMost(maxTokens)) }
+    }
+
+    // Prototype mapping. interface/enum are also `class_declaration` in this grammar; refining them
+    // to CODE_INTERFACE/CODE_ENUM requires inspecting the modifier/keyword children — left as TODO.
+    private fun String.toChunkKind(): ChunkKind? = when (this) {
+        "class_declaration" -> ChunkKind.CODE_CLASS
+        "object_declaration" -> ChunkKind.CODE_CLASS
+        "function_declaration" -> ChunkKind.CODE_FUNCTION
+        "property_declaration" -> ChunkKind.CODE_BLOCK
+        else -> null
+    }
+
+    // tree-sitter rows are 0-based; +1 → 1-based line numbers.
+    private fun lineOf(p: TSPoint): Int = p.row + 1
+
+    // endPoint is the position just past the node. When it lands at column 0 of a later row, the last
+    // real content line is the previous row, so use row as-is (1-based) to avoid bleeding into the
+    // next declaration or a trailing blank line.
+    private fun endLineOf(p: TSPoint): Int = if (p.column == 0 && p.row > 0) p.row else p.row + 1
+
+    private fun slice(bytes: ByteArray, startByte: Int, endByte: Int): String? {
+        if (startByte < 0 || endByte > bytes.size || startByte >= endByte) return null
+        return String(bytes, startByte, endByte - startByte, Charsets.UTF_8).takeIf { it.isNotBlank() }
+    }
+
+    private fun buildChunk(content: String, kind: ChunkKind, ordinal: Int, startLine: Int, endLine: Int): Chunk? {
+        if (content.isBlank()) return null
+        val safeStart = startLine.coerceAtLeast(1)
+        val safeEnd = endLine.coerceAtLeast(safeStart)
+        return Chunk(
+            id = 0,
+            fileId = 0,
+            ordinal = ordinal,
+            kind = kind,
+            startLine = safeStart,
+            endLine = safeEnd,
+            tokenEstimate = estimateTokens(content),
+            content = content,
+            summary = null,
+            createdAt = Instant.now()
+        )
+    }
+
+    private fun estimateTokens(text: String): Int = TokenEstimator.estimate(text)
+
+    private fun TSNode.namedChildren(): List<TSNode> = (0 until namedChildCount).map { getNamedChild(it) }
+}

--- a/src/test/kotlin/com/orchestrator/context/chunking/KotlinTreeSitterChunkerTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/chunking/KotlinTreeSitterChunkerTest.kt
@@ -1,0 +1,89 @@
+package com.orchestrator.context.chunking
+
+import com.orchestrator.context.domain.Chunk
+import com.orchestrator.context.domain.ChunkKind
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KotlinTreeSitterChunkerTest {
+
+    private val chunker = KotlinTreeSitterChunker(overlapPercent = 0)
+
+    @Test
+    fun `splits top-level declarations with real line ranges`() {
+        val src = """
+            package com.example
+
+            import kotlin.math.sqrt
+
+            class Foo(val x: Int) {
+                fun bar(): Int = x * 2
+            }
+
+            fun topLevel(a: Int): Int {
+                return a + 1
+            }
+        """.trimIndent()
+
+        val chunks = chunker.chunk(src, "Foo.kt")
+
+        // Header (package + imports), the class, and the top-level function.
+        assertTrue(chunks.any { it.kind == ChunkKind.CODE_HEADER }, "expected a header chunk")
+
+        val cls = chunks.firstOrNull { it.kind == ChunkKind.CODE_CLASS && it.content.contains("class Foo") }
+        assertNotNull(cls, "expected a CODE_CLASS chunk for Foo")
+        assertEquals(5, cls.startLine, "class should start on line 5")
+        assertEquals(7, cls.endLine, "class should end on line 7 (closing brace)")
+        assertTrue(cls.content.contains("fun bar()"), "class chunk must contain its body")
+
+        val fn = chunks.firstOrNull { it.kind == ChunkKind.CODE_FUNCTION && it.content.contains("fun topLevel") }
+        assertNotNull(fn, "expected a CODE_FUNCTION chunk for topLevel")
+        assertEquals(9, fn.startLine, "function should start on line 9")
+        assertEquals(11, fn.endLine, "function should end on line 11")
+
+        // Line ranges must be valid (Chunk requires 1 <= startLine <= endLine).
+        chunks.forEach { c ->
+            assertNotNull(c.startLine); assertNotNull(c.endLine)
+            assertTrue(c.startLine!! >= 1 && c.startLine!! <= c.endLine!!, "invalid range in $c")
+        }
+    }
+
+    @Test
+    fun `handles unicode in comments without shifting boundaries (utf-8 byte offsets)`() {
+        // A multibyte comment before the function would shift char vs byte offsets if mishandled.
+        val src = """
+            // Привет 世界 — заголовок
+            fun greet(): String = "hi"
+        """.trimIndent()
+
+        val chunks = chunker.chunk(src, "Greet.kt")
+        val fn = chunks.firstOrNull { it.kind == ChunkKind.CODE_FUNCTION }
+        assertNotNull(fn, "expected a function chunk")
+        assertTrue(fn.content.contains("fun greet()"), "function chunk must capture the declaration intact")
+    }
+
+    @Test
+    fun `falls back to heuristic chunker when nothing usable is parsed`() {
+        // No declarations at all — chunker must defer to the fallback rather than return nothing.
+        val markerChunk = Chunk(
+            id = 0, fileId = 0, ordinal = 0, kind = ChunkKind.CODE_BLOCK,
+            startLine = 1, endLine = 1, tokenEstimate = 1, content = "FALLBACK", summary = null,
+            createdAt = java.time.Instant.now()
+        )
+        val spyFallback = object : SimpleChunker {
+            var called = false
+            override fun chunk(content: String, filePath: String): List<Chunk> {
+                called = true
+                return listOf(markerChunk)
+            }
+        }
+        val c = KotlinTreeSitterChunker(overlapPercent = 0, fallback = spyFallback)
+
+        val result = c.chunk("// just a comment, no declarations\n", "Empty.kt")
+
+        assertTrue(spyFallback.called, "fallback must be invoked when no declarations are found")
+        assertEquals(listOf(markerChunk), result)
+    }
+}


### PR DESCRIPTION
**Prototype — not wired into ChunkerRegistry, so default indexing is unchanged.** Opening for review/discussion before deciding whether to adopt tree-sitter for code chunking.

Adds a `KotlinTreeSitterChunker` that splits Kotlin at top-level declarations from the real tree-sitter parse tree (boundaries + line ranges from the grammar instead of regex/brace heuristics). Backed by the bonede JNI binding (Java 11+, fits jvmToolchain(21)) + the Kotlin grammar.

### Findings baked into the implementation (the point of the prototype)
- The `tree-sitter-kotlin` grammar reports `hasError()` even on valid Kotlin, yet its declaration nodes/line ranges are correct — so we do **not** gate on `hasError()`; we extract usable declarations and fall back to `KotlinChunker` only on a thrown parse or an empty result.
- tree-sitter offsets are UTF-8 byte positions, not Java chars → content is sliced from the byte array (covered by a unicode-comment test).
- `endPoint` at column 0 is trimmed so a node doesn't bleed into the next declaration / a trailing blank line.

3 tests: line ranges, unicode byte-offset handling, fallback.

### Open items before adoption
- Wire into `ChunkerRegistry` (replace `kt`/`kts`) behind the ThreadLocal adapter (parsers aren't thread-safe).
- interface/enum currently map to `CODE_CLASS` (both are `class_declaration`); refine via child inspection.
- Recurse into `class_body` to chunk methods separately for parity with the heuristic chunker.
- Verify bundled native grammar libs cover all target platforms; fat-JAR size grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)