### PR TITLE
indexer: stop FK violation on shared git commit chunks

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/indexing/GitIntentLinkBuilder.kt
+++ b/src/main/kotlin/com/orchestrator/context/indexing/GitIntentLinkBuilder.kt
@@ -207,22 +207,12 @@ class GitIntentLinkBuilder(
         val chunkPath = "git/commit/${commit.hash}"
 
         return if (existingChunkId != null) {
-            conn.prepareStatement(
-                """
-                UPDATE chunks
-                SET token_count = ?, chunk_path = ?, parent_chunk_id = NULL,
-                    content = ?, summary = ?, created_at = ?
-                WHERE chunk_id = ?
-                """.trimIndent()
-            ).use { ps ->
-                ps.setInt(1, tokenEstimate)
-                ps.setString(2, chunkPath)
-                ps.setString(3, content)
-                ps.setString(4, commit.shortMessage)
-                ps.setTimestamp(5, Timestamp.from(now))
-                ps.setLong(6, existingChunkId)
-                ps.executeUpdate()
-            }
+            // Reuse the existing commit chunk as-is — do NOT UPDATE it. A commit is immutable by hash,
+            // so its message/content never change, making the update redundant. More importantly, a
+            // single commit chunk is shared by every file that commit touched: once one file's
+            // MODIFIES link references it (source_chunk_id), DuckDB forbids UPDATE/DELETE of that row
+            // (its foreign-key limitation), so updating here on the second+ file threw
+            // "key source_chunk_id: N is still referenced by a foreign key" and lost that file's links.
             existingChunkId
         } else {
             val chunkId = nextId(conn, "chunks_seq")

--- a/src/test/kotlin/com/orchestrator/context/indexing/GitIntentLinkBuilderTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/indexing/GitIntentLinkBuilderTest.kt
@@ -145,6 +145,83 @@ class GitIntentLinkBuilderTest {
         assertTrue(functionChunk.id in modifiesTargets)
     }
 
+    @Test
+    fun `shared commit across two files links both without FK violation`() {
+        // A commit that touched two files. The commit chunk is shared; building links for the second
+        // file must not fail trying to UPDATE the chunk already referenced by the first file's link
+        // (DuckDB forbids updating an FK-referenced row).
+        val (fileId1, chunk1, path1) = insertFileAndChunk("src/A.kt", "fun a() = Unit")
+        val (fileId2, chunk2, path2) = insertFileAndChunk("src/B.kt", "fun b() = Unit")
+
+        val commit = CommitInfo(
+            hash = "shared0commit0",
+            shortHash = "shared0",
+            author = AuthorInfo("Dev", "dev@example.com"),
+            committer = AuthorInfo("Dev", "dev@example.com"),
+            message = "Touch both A and B",
+            shortMessage = "Touch A and B",
+            timestamp = Instant.parse("2026-02-01T09:00:00Z"),
+            filesChanged = listOf("src/A.kt", "src/B.kt"),
+            additions = 2,
+            deletions = 0
+        )
+
+        val analyzer = mockk<GitHistoryAnalyzer>()
+        every { analyzer.getRecentCommits(path1, any()) } returns listOf(commit)
+        every { analyzer.getRecentCommits(path2, any()) } returns listOf(commit)
+        every { analyzer.getBlame(path1) } returns mapOf(1 to BlameInfo(1, "fun a() = Unit", commit))
+        every { analyzer.getBlame(path2) } returns mapOf(1 to BlameInfo(1, "fun b() = Unit", commit))
+
+        val builder = GitIntentLinkBuilder(analyzer = analyzer)
+        builder.rebuildForFile(fileId1)
+        builder.rebuildForFile(fileId2)
+
+        // Exactly one shared COMMIT_MESSAGE chunk, and MODIFIES links reach both files' chunks.
+        var commitChunkCount = 0
+        val modifiesTargets = mutableSetOf<Long>()
+        ContextDatabase.withConnection { conn ->
+            conn.prepareStatement("SELECT COUNT(*) FROM chunks WHERE kind = 'COMMIT_MESSAGE'").use { ps ->
+                ps.executeQuery().use { rs -> if (rs.next()) commitChunkCount = rs.getInt(1) }
+            }
+            conn.prepareStatement("SELECT target_chunk_id FROM links WHERE link_type = 'MODIFIES'").use { ps ->
+                ps.executeQuery().use { rs -> while (rs.next()) modifiesTargets += rs.getLong(1) }
+            }
+        }
+
+        assertTrue(commitChunkCount == 1, "the commit chunk must be shared, not duplicated (was $commitChunkCount)")
+        assertTrue(chunk1.id in modifiesTargets, "first file must be linked")
+        assertTrue(chunk2.id in modifiesTargets, "second file must be linked despite sharing the commit chunk")
+    }
+
+    private fun insertFileAndChunk(relPath: String, content: String): Triple<Long, Chunk, Path> {
+        val sourcePath = tempDir.resolve(relPath)
+        Files.createDirectories(sourcePath.parent)
+        Files.writeString(sourcePath, content)
+        val fileId = FileStateRepository.insert(
+            FileState(
+                id = 0,
+                relativePath = relPath,
+                absolutePath = sourcePath.toString(),
+                contentHash = "hash-$relPath",
+                sizeBytes = Files.size(sourcePath),
+                modifiedTimeNs = 1,
+                language = "kotlin",
+                kind = "code",
+                fingerprint = null,
+                indexedAt = Instant.now(),
+                isDeleted = false
+            )
+        ).id
+        val chunk = ChunkRepository.insert(
+            Chunk(
+                id = 0, fileId = fileId, ordinal = 0, kind = ChunkKind.CODE_FUNCTION,
+                startLine = 1, endLine = 1, tokenEstimate = 12, content = content,
+                summary = relPath, createdAt = Instant.now()
+            )
+        )
+        return Triple(fileId, chunk, sourcePath)
+    }
+
     private fun clearTables() {
         ContextDatabase.withConnection { conn ->
             conn.createStatement().use { st ->


### PR DESCRIPTION
A full reindex logged many `Violates foreign key constraint because key source_chunk_id: N is still referenced` warnings; the affected files got no git-intent (MODIFIES) links.

**Cause:** a commit-message chunk is shared by every file the commit touched. `upsertCommitChunk` UPDATEd that chunk on each referencing file; once the first file's link referenced it, DuckDB's FK limitation forbids updating that row, so later files sharing the commit threw and lost their links.

**Fix:** a commit is immutable by hash, so the UPDATE was redundant — reuse the existing commit chunk as-is, only insert this file's links. Regression test added (two files, one shared commit).

Independent of the chunking work; surfaced because the tree-sitter change required a full reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)