### PR TITLE
indexing: optional git links + stop false eps warning

### DIFF
--- a/fusionagent.toml
+++ b/fusionagent.toml
@@ -95,7 +95,7 @@ debounce_ms = 500
 #   watch_paths = ["."]                                       # Current directory
 #   watch_paths = ["/Users/sergeyrudenko/projects/codex_to_claude"]  # Absolute path
 watch_paths = [
-    "/Users/sergeyrudenko_1_2/PycharmProjects/jirat"
+    "/Users/sergeyrudenko_1_2/projects/deckers/pkg"
 ]
 
 # Periodically verify indexed files still exist (milliseconds). Set 0 to disable sweeps.
@@ -157,7 +157,7 @@ use_contextignore = true      # Also respects .contextignore (default: true) .co
 batch_size = 1024
 allowed_extensions = [
     ".kt", ".kts", ".java", ".go", ".py", ".ts", ".tsx", ".js", ".jsx",
-    ".json", ".md", ".markdown", ".yaml", ".yml", ".csv", ".txt", ".doc", ".docx", ".pdf", ".v", ".css", ".toml", ".sql"
+    ".json", ".md", ".markdown", ".yaml", ".yml", ".csv", ".txt", ".doc", ".docx", ".pdf", ".v", ".css", ".toml", ".sql", ".pkb", ".pks"
 ]
 
 # SKIP_PATTERNS: Exclude specific files AFTER extension filtering
@@ -241,6 +241,17 @@ binary_detection = "all"
 # Increase to be more permissive (e.g., 50 for UTF-8 heavy files)
 binary_threshold = 30
 
+# Build git-history (MODIFIES) links after indexing. This runs `git blame` per file via JGit and
+# can stall startup for minutes on large repos. Set to false to skip it.
+# Default: true
+git_intent_links = true
+
+# Warn if batch-indexing throughput drops below this (embeddings/sec). 0 disables the warning.
+# Heavy ONNX models on CPU run at single-digit eps (normal), so an absolute threshold is off by
+# default; set it to a value you know is abnormal for your model/hardware to catch regressions.
+# Default: 0 (disabled)
+min_eps_warn = 0
+
 # ------------------------------------------------------------------------------
 # [context.embedding] - Vector embedding configuration
 # ------------------------------------------------------------------------------
@@ -258,7 +269,7 @@ binary_threshold = 30
 # Optional: Path to custom ONNX model file
 # If specified, overrides the default bundled model
 # Fallback chain: model_path (if set) → ONNX_MODEL_PATH env var → default bundled model
- model_path = "/Users/sergeyrudenko_1_2/Downloads/model.onnx"
+ model_path = "/Users/sergeyrudenko_1_2/fusion-models/model.onnx"
 
 # Embedding dimension (must match your model's output)
 # Default: 384 (matches all-MiniLM-L6-v2)

--- a/src/main/kotlin/com/orchestrator/Main.kt
+++ b/src/main/kotlin/com/orchestrator/Main.kt
@@ -314,12 +314,17 @@ class Main {
             chunkerRegistry = ConfigurableChunkerRegistry(config.context.chunking)
         )
         val changeDetector = ChangeDetector(projectRoot, resolvedWatchRoots)
-        val batchIndexer = BatchIndexer(fileIndexer)
+        val batchIndexer = BatchIndexer(fileIndexer, minEpsWarn = config.context.indexing.minEpsWarn)
         val incrementalIndexer = IncrementalIndexer(
             changeDetector = changeDetector,
             batchIndexer = batchIndexer,
             crossFileLinkBuilder = com.orchestrator.context.indexing.CrossFileLinkBuilder(),
-            gitIntentLinkBuilder = com.orchestrator.context.indexing.GitIntentLinkBuilder()
+            // git-history links run `git blame` per file; disabling skips that startup cost.
+            gitIntentLinkBuilder = if (config.context.indexing.gitIntentLinks) {
+                com.orchestrator.context.indexing.GitIntentLinkBuilder()
+            } else {
+                null
+            }
         )
 
         val reconciler = StartupReconciler(
@@ -411,12 +416,17 @@ class Main {
                 chunkerRegistry = ConfigurableChunkerRegistry(config.context.chunking)
             )
             val changeDetector = ChangeDetector(projectRoot, resolvedWatchRoots)
-            val batchIndexer = BatchIndexer(fileIndexer)
+            val batchIndexer = BatchIndexer(fileIndexer, minEpsWarn = config.context.indexing.minEpsWarn)
             val incrementalIndexer = IncrementalIndexer(
                 changeDetector = changeDetector,
                 batchIndexer = batchIndexer,
                 crossFileLinkBuilder = com.orchestrator.context.indexing.CrossFileLinkBuilder(),
-                gitIntentLinkBuilder = com.orchestrator.context.indexing.GitIntentLinkBuilder()
+                // git-history links run `git blame` per file; disabling skips that startup cost.
+                gitIntentLinkBuilder = if (config.context.indexing.gitIntentLinks) {
+                    com.orchestrator.context.indexing.GitIntentLinkBuilder()
+                } else {
+                    null
+                }
             )
 
             WatcherDaemon(

--- a/src/main/kotlin/com/orchestrator/context/config/ContextConfig.kt
+++ b/src/main/kotlin/com/orchestrator/context/config/ContextConfig.kt
@@ -111,7 +111,13 @@ data class IndexingConfig(
     val followSymlinks: Boolean = false,
     val maxSymlinkDepth: Int = 3,
     val binaryDetection: BinaryDetectionMode = BinaryDetectionMode.ALL,
-    val binaryThreshold: Int = 30
+    val binaryThreshold: Int = 30,
+    // Build git-history (MODIFIES) links after indexing. This runs `git blame` per file via JGit and
+    // can stall startup for minutes on large repos, so it can be disabled.
+    val gitIntentLinks: Boolean = true,
+    // Warn if batch-indexing throughput drops below this (embeddings/sec). 0 disables the warning.
+    // Heavy ONNX models on CPU run at single-digit eps, which is normal, not a regression.
+    val minEpsWarn: Int = 0
 )
 
 data class EmbeddingConfig(

--- a/src/main/kotlin/com/orchestrator/context/config/ContextConfigLoader.kt
+++ b/src/main/kotlin/com/orchestrator/context/config/ContextConfigLoader.kt
@@ -165,7 +165,9 @@ object ContextConfigLoader {
             followSymlinks = table.getBoolean("follow_symlinks") ?: defaults.followSymlinks,
             maxSymlinkDepth = table.getLong("max_symlink_depth")?.toInt() ?: defaults.maxSymlinkDepth,
             binaryDetection = detection ?: defaults.binaryDetection,
-            binaryThreshold = table.getLong("binary_threshold")?.toInt() ?: defaults.binaryThreshold
+            binaryThreshold = table.getLong("binary_threshold")?.toInt() ?: defaults.binaryThreshold,
+            gitIntentLinks = table.getBoolean("git_intent_links") ?: defaults.gitIntentLinks,
+            minEpsWarn = table.getLong("min_eps_warn")?.toInt() ?: defaults.minEpsWarn
         )
     }
 

--- a/src/main/kotlin/com/orchestrator/context/indexing/BatchIndexer.kt
+++ b/src/main/kotlin/com/orchestrator/context/indexing/BatchIndexer.kt
@@ -25,7 +25,10 @@ class BatchIndexer(
     private val fileIndexer: FileIndexer,
     private val defaultParallelism: Int = max(Runtime.getRuntime().availableProcessors() - 1, 1),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val clock: Clock = Clock.systemUTC()
+    private val clock: Clock = Clock.systemUTC(),
+    // Warn when throughput falls below this (embeddings/sec). 0 disables it: heavy ONNX models on CPU
+    // run at single-digit eps, which is normal — an absolute threshold cried wolf every run.
+    private val minEpsWarn: Int = 0
 ) {
 
     private val log = Logger.logger("com.orchestrator.context.indexing.BatchIndexer")
@@ -183,11 +186,13 @@ class BatchIndexer(
             totalSeconds,
             finalEmbeddingsPerSecond.toInt()
         )
-        // Alert if performance is degraded: < 100 eps indicates memory or GC issues
-        if (totalEmbeddings > 0 && finalEmbeddingsPerSecond < 100) {
+        // Optional throughput warning, off by default (minEpsWarn = 0). Only meaningful as a
+        // regression signal relative to a baseline the operator knows for their model/hardware.
+        if (minEpsWarn > 0 && totalEmbeddings > 0 && finalEmbeddingsPerSecond < minEpsWarn) {
             log.warn(
-                "Batch indexing performance degraded: {} eps (expected 500+). Check memory and GC logs.",
-                finalEmbeddingsPerSecond.toInt()
+                "Batch indexing throughput {} eps is below the configured min_eps_warn={}",
+                finalEmbeddingsPerSecond.toInt(),
+                minEpsWarn
             )
         }
 

--- a/src/test/kotlin/com/orchestrator/context/config/ContextConfigLoaderTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/config/ContextConfigLoaderTest.kt
@@ -78,6 +78,36 @@ class ContextConfigLoaderTest {
     }
 
     @Test
+    fun `parses indexing git_intent_links and min_eps_warn with defaults`() {
+        val srcPath = Paths.get("src").toAbsolutePath()
+
+        // Defaults when the keys are absent.
+        val defaults = ContextConfigLoader.load(path = Paths.get("config/not-present-context.toml"))
+        assertTrue(defaults.indexing.gitIntentLinks, "git_intent_links defaults to true")
+        assertEquals(0, defaults.indexing.minEpsWarn, "min_eps_warn defaults to 0 (off)")
+
+        // Explicit overrides.
+        val tempDir = Files.createTempDirectory("context-config-indexing")
+        val tomlPath = tempDir.resolve("context.toml")
+        Files.writeString(
+            tomlPath,
+            """
+            [context.watcher]
+            enabled = true
+            watch_paths = ["${'$'}{SRC_PATH}"]
+
+            [context.indexing]
+            git_intent_links = false
+            min_eps_warn = 50
+            """.trimIndent()
+        )
+
+        val config = ContextConfigLoader.load(path = tomlPath, env = mapOf("SRC_PATH" to srcPath.toString()))
+        assertFalse(config.indexing.gitIntentLinks)
+        assertEquals(50, config.indexing.minEpsWarn)
+    }
+
+    @Test
     fun `expands environment variables in nested tables`() {
         val tempDir = Files.createTempDirectory("context-config-env")
         val tomlPath = tempDir.resolve("context.toml")


### PR DESCRIPTION
Startup-experience fixes surfaced during a fresh reindex.

- **Startup stall**: git-history (MODIFIES) links run `git blame` per file (JGit) on the main thread *before* the web/MCP servers start, so a large repo blocks startup for minutes with a silent terminal (looked like a hang / "web didn't open"). New `context.indexing.git_intent_links` (default `true`) skips it.
- **False eps warning**: `BatchIndexer` warned `performance degraded: N eps (expected 500+). Check memory and GC logs` every run — the 500/100 threshold suits the lightweight bundled model but cries wolf with any heavy ONNX model on CPU (single-digit eps is normal). Replaced with `context.indexing.min_eps_warn` (default `0` = off); the completion line already logs throughput.

Config parsed + documented in fusionagent.toml; test covers parsing/defaults.
🤖 Generated with [Claude Code](https://claude.com/claude-code)