### PR TITLE
chunking: split PL/SQL packages into per-member chunks

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/chunking/SqlChunker.kt
+++ b/src/main/kotlin/com/orchestrator/context/chunking/SqlChunker.kt
@@ -37,21 +37,94 @@ class SqlChunker(
     /** A SQL statement together with its 1-based inclusive line span in the source file. */
     private data class SqlStatement(val text: String, val startLine: Int, val endLine: Int)
 
+    /** A labelled, line-located piece of a statement (used to break a package into its members). */
+    private data class LabeledPiece(val label: String, val text: String, val startLine: Int, val endLine: Int)
+
+    // A package/type member sub-program declaration, optionally prefixed by type-method modifiers.
+    private val memberStartRegex = Regex(
+        """^\s*(?:(?:MEMBER|STATIC|MAP|ORDER|FINAL|OVERRIDING|CONSTRUCTOR)\s+)*(PROCEDURE|FUNCTION)\s+("?[\w${'$'}#]+"?)""",
+        RegexOption.IGNORE_CASE
+    )
+
     override fun chunk(content: String, filePath: String): List<Chunk> {
         if (content.isBlank()) return emptyList()
 
         val chunks = mutableListOf<Chunk>()
         val statements = splitStatements(content)
+        var ordinal = 0
 
-        statements.forEachIndexed { index, statement ->
-            val trimmed = statement.text.trim()
-            if (trimmed.isNotEmpty()) {
-                val label = extractLabel(trimmed)
-                chunks.add(createChunk(statement.text, label, index, statement.startLine, statement.endLine))
+        statements.forEach { statement ->
+            if (statement.text.isBlank()) return@forEach
+            // A PACKAGE/TYPE [BODY] arrives as a single statement; break it into member sub-programs
+            // so a large package isn't one giant chunk (e.g. a 700KB package body → one embedding).
+            val pieces = if (packageStartRegex.containsMatchIn(statement.text.trimStart())) {
+                splitPackageMembers(statement)
+            } else {
+                listOf(LabeledPiece(extractLabel(statement.text.trim()), statement.text, statement.startLine, statement.endLine))
+            }
+            pieces.forEach { piece ->
+                if (piece.text.isNotBlank()) {
+                    chunks.add(createChunk(piece.text, piece.label, ordinal++, piece.startLine, piece.endLine))
+                }
             }
         }
 
         return OverlapProcessor.addOverlap(chunks, overlapPercent, ::estimateTokens)
+    }
+
+    /**
+     * Break a PACKAGE / PACKAGE BODY (or TYPE BODY) into a header chunk plus one chunk per member
+     * sub-program. A member starts at a top-level `PROCEDURE`/`FUNCTION` (depth 0, i.e. not inside
+     * another member's BEGIN..END body) and runs until the next member start or the package end.
+     * Returns the package as a single piece if no members are found (e.g. a thin package spec).
+     */
+    private fun splitPackageMembers(statement: SqlStatement): List<LabeledPiece> {
+        val lines = statement.text.split("\n")
+        val packageLabel = extractLabel(statement.text.trim())
+
+        // Find member-start line indices that sit at package level (BEGIN/END depth 0).
+        val starts = mutableListOf<Pair<Int, String>>() // index to "PROCEDURE name" / "FUNCTION name"
+        var depth = 0
+        for ((i, line) in lines.withIndex()) {
+            val upper = line.uppercase(Locale.US)
+            if (depth == 0) {
+                memberStartRegex.find(line)?.let { m ->
+                    val kind = m.groupValues[1].uppercase(Locale.US)
+                    val name = m.groupValues[2].trim('"')
+                    starts += i to "$kind $name"
+                }
+            }
+            if (beginRegex.containsMatchIn(upper)) depth += 1
+            if (blockEndRegex.containsMatchIn(upper)) depth = (depth - 1).coerceAtLeast(0)
+        }
+
+        if (starts.isEmpty()) {
+            return listOf(LabeledPiece(packageLabel, statement.text, statement.startLine, statement.endLine))
+        }
+
+        val pieces = mutableListOf<LabeledPiece>()
+        val base = statement.startLine
+
+        // Header: package declaration + package-level globals, up to the first member.
+        val firstStart = starts.first().first
+        if (firstStart > 0) {
+            val headerText = lines.subList(0, firstStart).joinToString("\n").trimEnd()
+            if (headerText.isNotBlank()) {
+                pieces += LabeledPiece(packageLabel, headerText, base, base + firstStart - 1)
+            }
+        }
+
+        // Each member spans from its start line to just before the next member start (last → end).
+        for ((k, start) in starts.withIndex()) {
+            val startIdx = start.first
+            val endIdx = if (k + 1 < starts.size) starts[k + 1].first - 1 else lines.lastIndex
+            val text = lines.subList(startIdx, endIdx + 1).joinToString("\n").trimEnd()
+            if (text.isNotBlank()) {
+                pieces += LabeledPiece(start.second, text, base + startIdx, base + endIdx)
+            }
+        }
+
+        return pieces
     }
 
     private fun splitStatements(content: String): List<SqlStatement> {

--- a/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerOracleTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerOracleTest.kt
@@ -36,7 +36,7 @@ class SqlChunkerOracleTest {
     }
 
     @Test
-    fun `CREATE OR REPLACE PACKAGE BODY stays whole and terminates on slash`() {
+    fun `package body splits into per-member chunks and is not fragmented by inner semicolons`() {
         val sql = """
             CREATE OR REPLACE PACKAGE BODY pkg AS
               PROCEDURE a IS BEGIN NULL; END a;
@@ -46,13 +46,16 @@ class SqlChunkerOracleTest {
         """.trimIndent()
 
         val chunks = chunker.chunk(sql, "pkg.pkb")
+        val labels = chunks.mapNotNull { it.summary }
 
-        assertEquals(1, chunks.size, "a package body's inner procedure ENDs must not split it")
-        val c = chunks.single()
-        assertEquals("CREATE PACKAGE BODY pkg", c.summary)
-        assertTrue(c.content.contains("PROCEDURE a") && c.content.contains("PROCEDURE b"))
-        assertEquals(1, c.startLine)
-        assertEquals(4, c.endLine, "ends at 'END pkg;' (line 4); the '/' is dropped")
+        // The package is split at member boundaries (header + a + b), but NOT fragmented by the
+        // inner `;` of each one-line procedure (each member stays intact).
+        assertTrue("PROCEDURE a" in labels, "labels=$labels")
+        assertTrue("PROCEDURE b" in labels, "labels=$labels")
+        val a = chunks.first { it.summary == "PROCEDURE a" }
+        assertTrue(a.content.contains("BEGIN NULL; END a;"), "member A must stay intact: '${a.content}'")
+        // No chunk should hold both members (proves real splitting, not one giant chunk).
+        assertTrue(chunks.none { it.content.contains("END a;") && it.content.contains("END b;") })
     }
 
     @Test

--- a/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerPackageTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerPackageTest.kt
@@ -1,0 +1,87 @@
+package com.orchestrator.context.chunking
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** PL/SQL package bodies/specs must split into per-member chunks, not one giant chunk. */
+class SqlChunkerPackageTest {
+
+    private val chunker = SqlChunker(overlapPercent = 0)
+
+    @Test
+    fun `package body splits into header and one chunk per member`() {
+        val sql = """
+            CREATE OR REPLACE PACKAGE BODY pkg AS
+              g_const CONSTANT NUMBER := 1;
+
+              PROCEDURE init_log IS
+              BEGIN
+                NULL;
+              END init_log;
+
+              FUNCTION calc(p IN NUMBER) RETURN NUMBER IS
+                v NUMBER;
+              BEGIN
+                v := p * 2;
+                IF v > 10 THEN
+                  v := 10;
+                END IF;
+                RETURN v;
+              END calc;
+
+              PROCEDURE finish IS
+              BEGIN
+                NULL;
+              END finish;
+            END pkg;
+            /
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "pkg.pkb")
+        val labels = chunks.mapNotNull { it.summary }
+
+        // Header + 3 members, not a single chunk.
+        assertTrue(chunks.size >= 4, "expected header + 3 members, got ${chunks.size}: $labels")
+        assertTrue(labels.any { it.contains("PACKAGE BODY pkg") }, "header label missing: $labels")
+        assertTrue("PROCEDURE init_log" in labels, "labels=$labels")
+        assertTrue("FUNCTION calc" in labels, "labels=$labels")
+        assertTrue("PROCEDURE finish" in labels, "labels=$labels")
+
+        // No single chunk should contain all three members (i.e. it really split).
+        assertTrue(
+            chunks.none { it.content.contains("init_log") && it.content.contains("calc") && it.content.contains("finish") },
+            "a chunk still contains every member — package was not split"
+        )
+
+        // The calc member chunk keeps its whole body (END IF must not have split it).
+        val calc = chunks.first { it.summary == "FUNCTION calc" }
+        assertTrue(calc.content.contains("RETURN v") && calc.content.contains("END calc"))
+
+        // Line ranges valid and ascending.
+        chunks.forEach { c -> assertTrue(c.startLine != null && c.endLine != null && c.startLine!! <= c.endLine!!) }
+    }
+
+    @Test
+    fun `package spec splits declarations into members`() {
+        val sql = """
+            CREATE OR REPLACE PACKAGE pkg AS
+              PROCEDURE do_a(p IN NUMBER);
+              FUNCTION get_b RETURN VARCHAR2;
+            END pkg;
+            /
+        """.trimIndent()
+
+        val labels = chunker.chunk(sql, "pkg.pks").mapNotNull { it.summary }
+        assertTrue("PROCEDURE do_a" in labels, "labels=$labels")
+        assertTrue("FUNCTION get_b" in labels, "labels=$labels")
+    }
+
+    @Test
+    fun `non-package sql is unaffected`() {
+        val sql = "CREATE TABLE users (id INT PRIMARY KEY);"
+        val chunks = chunker.chunk(sql, "schema.sql")
+        assertEquals(1, chunks.size)
+        assertEquals("CREATE TABLE users", chunks.single().summary)
+    }
+}


### PR DESCRIPTION
A `PACKAGE` / `PACKAGE BODY` was one chunk, so a large Oracle package body (real example: a **711KB** `.pkb`) became a single chunk → one truncated embedding, losing nearly all of it for search.

**Fix:** break a package into a header chunk (declaration + package-level globals) plus one chunk per member sub-program. A member starts at a top-level `PROCEDURE`/`FUNCTION` (BEGIN/END depth 0 — not inside another member's body) and runs to the next member start or the package end; `END IF/LOOP/CASE` are excluded from depth so a member isn't split mid-body. Labels: `PROCEDURE name` / `FUNCTION name`. Thin specs without members fall back to a single chunk.

**Verified on the real deckers packages:** sample.pkb 1→13, grn.pkb 1→25, **3pl.pkb 1→97 (96 members)**, 3pl.pks 1→40. Tests cover body/spec splitting, member integrity, and that non-package SQL is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)