### PR TITLE
graph: build intra-file CALLS edges so impact_radius finds in-file callers

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/ContextRepository.kt
+++ b/src/main/kotlin/com/orchestrator/context/ContextRepository.kt
@@ -367,6 +367,36 @@ object ContextRepository {
         }
     }
 
+    /**
+     * Fetch persisted [FileState]s for a specific set of absolute paths, keyed by absolute path.
+     *
+     * Incremental change detection only needs the states of the handful of files it is checking, not
+     * the whole catalog. Querying just those paths (via an indexed abs_path lookup) avoids loading
+     * the entire file_state table on every watcher batch — which made each batch O(total files) and
+     * progressively slower as the corpus grew. Chunked to stay within parameter limits.
+     */
+    fun getFilesByAbsolutePaths(absolutePaths: Collection<String>): Map<String, FileState> {
+        if (absolutePaths.isEmpty()) return emptyMap()
+        val distinct = absolutePaths.toHashSet()
+        val result = HashMap<String, FileState>(distinct.size)
+        ContextDatabase.withConnection { conn ->
+            distinct.chunked(500).forEach { batch ->
+                val placeholders = batch.joinToString(",") { "?" }
+                val sql = "SELECT * FROM file_state WHERE abs_path IN ($placeholders)"
+                conn.prepareStatement(sql).use { ps ->
+                    batch.forEachIndexed { i, p -> ps.setString(i + 1, p) }
+                    ps.executeQuery().use { rs ->
+                        while (rs.next()) {
+                            val state = rs.toFileState()
+                            result[state.absolutePath] = state
+                        }
+                    }
+                }
+            }
+        }
+        return result
+    }
+
     fun countActiveFiles(): Long = ContextDatabase.withConnection { conn ->
         conn.prepareStatement("SELECT COUNT(*) FROM file_state WHERE is_deleted = FALSE").use { ps ->
             ps.executeQuery().use { rs ->
@@ -1051,6 +1081,31 @@ object ContextRepository {
                     }
                     results
                 }
+            }
+        }
+    }
+
+    /**
+     * Count inbound graph edges (of [linkTypes]) pointing at the given chunks. Used by
+     * get_impact_radius to tell "no callers exist" (count 0) apart from a non-empty graph that simply
+     * had nothing to surface, so an impactCount of 0 is interpretable rather than a silent gap.
+     */
+    fun countInboundEdges(chunkIds: List<Long>, linkTypes: Set<String>? = null): Int {
+        if (chunkIds.isEmpty()) return 0
+        val placeholders = chunkIds.joinToString(",") { "?" }
+        val typeFilter = if (linkTypes.isNullOrEmpty()) "" else
+            " AND link_type IN (${linkTypes.joinToString(",") { "?" }})"
+        val sql = """
+            SELECT COUNT(*) FROM links
+            WHERE target_chunk_id IN ($placeholders)
+              AND source_chunk_id IS NOT NULL$typeFilter
+        """.trimIndent()
+        return ContextDatabase.withConnection { conn ->
+            conn.prepareStatement(sql).use { ps ->
+                var idx = 1
+                chunkIds.forEach { ps.setLong(idx++, it) }
+                linkTypes?.forEach { ps.setString(idx++, it) }
+                ps.executeQuery().use { rs -> if (rs.next()) rs.getInt(1) else 0 }
             }
         }
     }

--- a/src/main/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilder.kt
+++ b/src/main/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilder.kt
@@ -418,12 +418,18 @@ class CrossFileLinkBuilder(
         importedFileIds: Set<Long>
     ): TargetSymbol? {
         if (candidates.isEmpty()) return null
+        // Same-file targets are kept (only the calling chunk itself is excluded). Intra-file calls —
+        // e.g. one PL/SQL package procedure calling another in the same .pkb, or a method calling a
+        // sibling method — are real CALLS edges; excluding them left get_impact_radius unable to find
+        // intra-file/intra-package callers (a silent false negative on blast radius). Local scope is
+        // preferred: an unqualified call resolves to a same-file subprogram before a cross-file one,
+        // matching how most languages (and Oracle PL/SQL) resolve names.
         return candidates
             .asSequence()
-            .filter { it.fileId != sourceFileId }
             .filter { it.chunkId != sourceChunkId }
             .sortedWith(
-                compareBy<TargetSymbol> { if (it.fileId in importedFileIds) 0 else 1 }
+                compareBy<TargetSymbol> { if (it.fileId == sourceFileId) 0 else 1 }
+                    .thenBy { if (it.fileId in importedFileIds) 0 else 1 }
                     .thenBy { symbolTypePriority(it.symbolType) }
                     .thenBy { it.qualifiedName?.length ?: Int.MAX_VALUE }
             )

--- a/src/main/kotlin/com/orchestrator/mcp/McpServerImpl.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/McpServerImpl.kt
@@ -1447,6 +1447,9 @@ class McpServerImpl(
         put("testCount", JsonPrimitive(result.testCount))
         put("droppedDueToBudget", JsonPrimitive(result.droppedDueToBudget))
         put("tokensUsed", JsonPrimitive(result.tokensUsed))
+        // Disambiguates impactCount == 0: 0 here means no recorded callers/dependents for the seeds;
+        // > 0 means edges exist but were filtered (e.g. all callers were themselves seeds).
+        put("seedInboundEdges", JsonPrimitive(result.seedInboundEdges))
         put("chunks", buildJsonArray {
             result.chunks.forEach { c ->
                 add(buildJsonObject {

--- a/src/main/kotlin/com/orchestrator/mcp/tools/GetImpactRadiusTool.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/tools/GetImpactRadiusTool.kt
@@ -67,19 +67,24 @@ class GetImpactRadiusTool(
         val testCount: Int,
         val droppedDueToBudget: Int,
         val tokensUsed: Int,
+        // Inbound CALLS/DEPENDS_ON/MODIFIES edges pointing at the seed chunks. Lets a caller tell
+        // "no callers exist" (0) apart from "the graph simply surfaced nothing": impactCount=0 with
+        // seedInboundEdges>0 means callers exist but were filtered (budget/seed-overlap), while
+        // impactCount=0 with seedInboundEdges=0 means no recorded callers for these chunks.
+        val seedInboundEdges: Int,
         val chunks: List<ImpactChunk>
     )
 
     fun execute(params: Params): Result {
         val regions = buildRegions(params)
         if (regions.isEmpty()) {
-            return Result(0, 0, 0, 0, 0, emptyList())
+            return Result(0, 0, 0, 0, 0, 0, emptyList())
         }
 
         val seedIds = diffResolver.resolveSeedChunks(regions)
         if (seedIds.isEmpty()) {
             log.debug("get_impact_radius: no seed chunks resolved from {} regions", regions.size)
-            return Result(0, 0, 0, 0, 0, emptyList())
+            return Result(0, 0, 0, 0, 0, 0, emptyList())
         }
 
         val depth = params.maxDepth.coerceAtLeast(1)
@@ -196,12 +201,16 @@ class GetImpactRadiusTool(
             )
         }
 
+        // Honest signal for impactCount == 0: are there *any* inbound edges to the seeds at all?
+        val seedInboundEdges = ContextRepository.countInboundEdges(seedIds, IMPACT_EDGE_TYPES)
+
         return Result(
             seedCount = seedIds.size,
             impactCount = impactById.size,
             testCount = testById.size,
             droppedDueToBudget = dropped,
             tokensUsed = tokensUsed,
+            seedInboundEdges = seedInboundEdges,
             chunks = impactChunks
         )
     }

--- a/src/test/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilderTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilderTest.kt
@@ -6,6 +6,7 @@ import com.orchestrator.context.domain.ChunkKind
 import com.orchestrator.context.domain.FileState
 import com.orchestrator.context.domain.SymbolRecord
 import com.orchestrator.context.domain.SymbolType
+import com.orchestrator.context.ContextRepository
 import com.orchestrator.context.storage.ChunkRepository
 import com.orchestrator.context.storage.ContextDatabase
 import com.orchestrator.context.storage.FileStateRepository
@@ -277,6 +278,131 @@ class CrossFileLinkBuilderTest {
             }
         }
         assertTrue(coversCount == 0, "Non-test source must not produce COVERS edges")
+    }
+
+    @Test
+    fun `builds intra-file CALLS edge so reverse traversal finds an in-file caller`() {
+        // One file, two subprograms: caller() invokes callee() in the same file (PL/SQL-style
+        // intra-package call). Previously the same-file CALLS edge was never built, so
+        // get_impact_radius (reverse traversal) returned zero callers — a false negative.
+        val fileId = insertFile("pkg/sample.pkb")
+
+        val callerChunk = ChunkRepository.insert(
+            Chunk(
+                id = 0, fileId = fileId, ordinal = 0, kind = ChunkKind.CODE_FUNCTION,
+                startLine = 1, endLine = 3, tokenEstimate = 12,
+                content = "PROCEDURE caller IS BEGIN callee(); END caller;", summary = "caller",
+                createdAt = Instant.now()
+            )
+        )
+        val calleeChunk = ChunkRepository.insert(
+            Chunk(
+                id = 0, fileId = fileId, ordinal = 1, kind = ChunkKind.CODE_FUNCTION,
+                startLine = 5, endLine = 7, tokenEstimate = 10,
+                content = "PROCEDURE callee IS BEGIN NULL; END callee;", summary = "callee",
+                createdAt = Instant.now()
+            )
+        )
+        SymbolRepository.replaceForFile(
+            fileId,
+            listOf(
+                SymbolRecord(
+                    id = 0, fileId = fileId, chunkId = callerChunk.id, symbolType = SymbolType.FUNCTION,
+                    name = "caller", qualifiedName = "pkg.caller", signature = "PROCEDURE caller",
+                    language = "plsql", startLine = 1, endLine = 3, createdAt = Instant.now()
+                ),
+                SymbolRecord(
+                    id = 0, fileId = fileId, chunkId = calleeChunk.id, symbolType = SymbolType.FUNCTION,
+                    name = "callee", qualifiedName = "pkg.callee", signature = "PROCEDURE callee",
+                    language = "plsql", startLine = 5, endLine = 7, createdAt = Instant.now()
+                )
+            )
+        )
+
+        CrossFileLinkBuilder().rebuildForFile(fileId)
+
+        var found = false
+        ContextDatabase.withConnection { conn ->
+            conn.prepareStatement(
+                "SELECT 1 FROM links WHERE source_chunk_id = ? AND target_chunk_id = ? AND link_type = 'CALLS'"
+            ).use { ps ->
+                ps.setLong(1, callerChunk.id)
+                ps.setLong(2, calleeChunk.id)
+                ps.executeQuery().use { rs -> found = rs.next() }
+            }
+        }
+        assertTrue(found, "expected an intra-file CALLS edge caller -> callee")
+
+        // Reverse traversal from the callee must surface the caller (what get_impact_radius does).
+        val callers = ContextRepository.traverseGraphReverse(
+            seedChunkIds = listOf(calleeChunk.id),
+            maxDepth = 3,
+            linkTypes = setOf("CALLS", "DEPENDS_ON", "MODIFIES")
+        ).map { it.chunkId }
+        assertTrue(callerChunk.id in callers, "reverse traversal must find the in-file caller")
+    }
+
+    @Test
+    fun `rebuildForFiles builds links for multiple files in one batch`() {
+        // Two source files, each calling/importing a symbol defined in a shared target file.
+        val target = insertFile("src/Target.kt")
+        val targetChunk = ChunkRepository.insert(
+            Chunk(
+                id = 0, fileId = target, ordinal = 0, kind = ChunkKind.CODE_FUNCTION,
+                startLine = 1, endLine = 4, tokenEstimate = 10,
+                content = "fun fooService() = Unit", summary = "fooService", createdAt = Instant.now()
+            )
+        )
+        SymbolRepository.replaceForFile(
+            target,
+            listOf(
+                SymbolRecord(
+                    id = 0, fileId = target, chunkId = targetChunk.id, symbolType = SymbolType.FUNCTION,
+                    name = "fooService", qualifiedName = "com.example.fooService",
+                    signature = "fun fooService()", language = "kotlin",
+                    startLine = 1, endLine = 1, createdAt = Instant.now()
+                )
+            )
+        )
+
+        val sourceChunkIds = listOf("src/S1.kt", "src/S2.kt").map { rel ->
+            val fileId = insertFile(rel)
+            val chunk = ChunkRepository.insert(
+                Chunk(
+                    id = 0, fileId = fileId, ordinal = 0, kind = ChunkKind.CODE_FUNCTION,
+                    startLine = 1, endLine = 6, tokenEstimate = 20,
+                    content = "fun invoke() { fooService() }", summary = "invoke", createdAt = Instant.now()
+                )
+            )
+            SymbolRepository.replaceForFile(
+                fileId,
+                listOf(
+                    SymbolRecord(
+                        id = 0, fileId = fileId, chunkId = chunk.id, symbolType = SymbolType.FUNCTION,
+                        name = "invoke", qualifiedName = null, signature = "fun invoke()",
+                        language = "kotlin", startLine = 1, endLine = 1, createdAt = Instant.now()
+                    )
+                )
+            )
+            fileId to chunk.id
+        }
+
+        CrossFileLinkBuilder().rebuildForFiles(sourceChunkIds.map { it.first })
+
+        // Every source chunk must have a CALLS edge into the shared target chunk.
+        sourceChunkIds.forEach { (_, chunkId) ->
+            var calls = false
+            ContextDatabase.withConnection { conn ->
+                conn.prepareStatement(
+                    "SELECT 1 FROM links WHERE source_chunk_id = ? AND target_chunk_id = ? AND link_type = 'CALLS'"
+                ).use { ps ->
+                    ps.setLong(1, chunkId)
+                    ps.setLong(2, targetChunk.id)
+                    ps.executeQuery().use { rs -> calls = rs.next() }
+                }
+            }
+            assertTrue(calls, "batch rebuild must create CALLS edge for source chunk $chunkId")
+        }
     }
 
     @Test


### PR DESCRIPTION
`get_impact_radius` returned `impactCount=0` even when a caller existed — a **false negative** on review/pre-merge blast radius (the user verified callers exist via grep where the tool returned 0).

**Cause:** the link builder excluded same-file CALLS targets (`fileId != sourceFileId`), so a procedure calling another procedure in the **same package/file** (the common case in Oracle PL/SQL, and any same-file method call) produced **no edge**. The reverse traversal was correct; the edge never existed. Affects **every language**.

**Fix:**
- `selectCallTarget` keeps same-file targets (only the calling chunk itself is excluded) and **prefers local scope** — an unqualified call resolves to a same-file subprogram before a cross-file one (matches PL/SQL and most languages).
- Added `seedInboundEdges` to the result (+ `ContextRepository.countInboundEdges`) so `impactCount=0` is interpretable: `0` = no recorded callers; `>0` = callers exist but were filtered (e.g. all were seeds).

Test: single-file caller→callee builds the CALLS edge and reverse traversal surfaces the in-file caller.

Known remaining: paren-less PL/SQL procedure calls (`proc;` with no args) aren't tokenized by the call-token regex — a separate follow-up.
🤖 Generated with [Claude Code](https://claude.com/claude-code)