### PR TITLE
graph: capture parameterless PL/SQL calls + drop spec->body false edges

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilder.kt
+++ b/src/main/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilder.kt
@@ -112,7 +112,14 @@ class CrossFileLinkBuilder(
 
         val imports = loadImportSymbols(conn, fileId)
         val callTokensByChunk = sourceChunks.associate { chunk ->
-            chunk.chunkId to extractCallTokens(chunk.content)
+            // PL/SQL (SQL_STATEMENT chunks) calls parameterless procedures as bare `name;` with no
+            // parens, which the `name(` regex misses — add those so intra-package callers are found.
+            val tokens = if (chunk.kind == "SQL_STATEMENT") {
+                extractCallTokens(chunk.content) + extractParenlessCallTokens(chunk.content)
+            } else {
+                extractCallTokens(chunk.content)
+            }
+            chunk.chunkId to tokens.distinct()
         }
         val callTokens = callTokensByChunk.values.flatten().toSet()
         val importNames = imports
@@ -227,7 +234,7 @@ class CrossFileLinkBuilder(
 
     private fun loadSourceChunks(conn: Connection, fileId: Long): List<SourceChunk> {
         val sql = """
-            SELECT chunk_id, file_id, ordinal, start_line, end_line, content
+            SELECT chunk_id, file_id, ordinal, start_line, end_line, content, kind
             FROM chunks
             WHERE file_id = ?
               AND (kind LIKE 'CODE_%' OR kind = 'SQL_STATEMENT')
@@ -244,7 +251,8 @@ class CrossFileLinkBuilder(
                         ordinal = rs.getInt("ordinal"),
                         startLine = rs.getInt("start_line").takeIf { !rs.wasNull() },
                         endLine = rs.getInt("end_line").takeIf { !rs.wasNull() },
-                        content = rs.getString("content").orEmpty()
+                        content = rs.getString("content").orEmpty(),
+                        kind = rs.getString("kind").orEmpty()
                     )
                 }
                 chunks
@@ -476,11 +484,34 @@ class CrossFileLinkBuilder(
         return tokens.toList()
     }
 
+    /**
+     * Parameterless PL/SQL calls: a statement that is just `name;` (or `pkg.name;`) — a procedure
+     * with no arguments is invoked without parentheses, which [extractCallTokens] misses. Excludes
+     * statement keywords (NULL;/RETURN;/COMMIT;/END name;/etc.) and assignments. The unqualified last
+     * segment is the call name, matching how the call graph resolves by symbol name.
+     */
+    private fun extractParenlessCallTokens(content: String): List<String> {
+        if (content.isBlank()) return emptyList()
+        val tokens = LinkedHashSet<String>()
+        content.lineSequence().forEach { rawLine ->
+            val line = rawLine.trim()
+            if (line.isEmpty() || line.startsWith("--")) return@forEach
+            val match = parenlessCallRegex.matchEntire(line) ?: return@forEach
+            val token = match.groupValues[1].substringAfterLast('.').lowercase(Locale.US)
+            if (token.length < 2) return@forEach
+            if (token in ignoredCallTokens || token in plsqlStatementKeywords) return@forEach
+            tokens += token
+        }
+        return tokens.toList()
+    }
+
     private fun looksLikeDeclaration(line: String, token: String, index: Int): Boolean {
         if (index <= 0 || index > line.length) return false
+        // True when the identifier is immediately preceded by a declaration keyword (e.g. `fun foo(`,
+        // `PROCEDURE foo(`). Match the keyword right before the token — the token is not in `prefix`.
         val prefix = line.substring(0, index)
         return declarationPrefixes.any { kw ->
-            Regex("""\b$kw\s+$token\s*$""", RegexOption.IGNORE_CASE).containsMatchIn(prefix)
+            Regex("""\b$kw\s+$""", RegexOption.IGNORE_CASE).containsMatchIn(prefix)
         }
     }
 
@@ -509,7 +540,8 @@ class CrossFileLinkBuilder(
         val ordinal: Int,
         val startLine: Int?,
         val endLine: Int?,
-        val content: String
+        val content: String,
+        val kind: String
     )
 
     private data class ImportSymbol(
@@ -562,11 +594,25 @@ class CrossFileLinkBuilder(
         }
 
         private val callRegex = Regex("""\b([A-Za-z_][A-Za-z0-9_]*)\s*\(""")
-        private val declarationPrefixes = setOf("fun", "def", "function", "class", "interface", "enum", "object")
+        // A whole statement that is just an identifier (optionally schema/package-qualified) + `;` —
+        // a parameterless PL/SQL procedure call. Excludes anything with operators/args.
+        private val parenlessCallRegex =
+            Regex("""([A-Za-z_][A-Za-z0-9_${'$'}#]*(?:\.[A-Za-z_][A-Za-z0-9_${'$'}#]*)*)\s*;""")
+        // `PROCEDURE`/`FUNCTION`/`TRIGGER` added so PL/SQL declarations (incl. .pks spec lines) are not
+        // mistaken for calls — that was creating false "spec-declaration -> body" CALLS edges.
+        private val declarationPrefixes = setOf(
+            "fun", "def", "function", "class", "interface", "enum", "object",
+            "procedure", "trigger"
+        )
         private val ignoredCallTokens = setOf(
             "if", "for", "while", "when", "switch", "catch", "return", "throw",
             "try", "with", "super", "this", "new", "println", "print", "log",
             "map", "filter", "reduce", "listof", "setof", "arrayof"
+        )
+        // Bare `name;` statements that are PL/SQL keywords, not procedure calls.
+        private val plsqlStatementKeywords = setOf(
+            "null", "return", "exit", "continue", "commit", "rollback", "begin", "end",
+            "goto", "raise", "savepoint", "loop", "else"
         )
     }
 }

--- a/src/test/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilderTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilderTest.kt
@@ -343,6 +343,57 @@ class CrossFileLinkBuilderTest {
     }
 
     @Test
+    fun `intra-package parameterless PL-SQL call builds a CALLS edge`() {
+        // PL/SQL invokes a no-arg procedure without parentheses: `callee;`. The `name(` regex misses
+        // it, so the call graph (and get_impact_radius reverse traversal) saw no caller.
+        val fileId = insertFile("pkg/body.pkb")
+
+        val callerChunk = ChunkRepository.insert(
+            Chunk(
+                id = 0, fileId = fileId, ordinal = 0, kind = ChunkKind.SQL_STATEMENT,
+                startLine = 1, endLine = 4, tokenEstimate = 12,
+                content = "PROCEDURE caller IS\nBEGIN\n  callee;\nEND caller;", summary = "PROCEDURE caller",
+                createdAt = Instant.now()
+            )
+        )
+        val calleeChunk = ChunkRepository.insert(
+            Chunk(
+                id = 0, fileId = fileId, ordinal = 1, kind = ChunkKind.SQL_STATEMENT,
+                startLine = 6, endLine = 9, tokenEstimate = 10,
+                content = "PROCEDURE callee IS\nBEGIN\n  NULL;\nEND callee;", summary = "PROCEDURE callee",
+                createdAt = Instant.now()
+            )
+        )
+        SymbolRepository.replaceForFile(
+            fileId,
+            listOf(
+                SymbolRecord(
+                    id = 0, fileId = fileId, chunkId = callerChunk.id, symbolType = SymbolType.FUNCTION,
+                    name = "caller", qualifiedName = "pkg.caller", signature = "PROCEDURE caller",
+                    language = "plsql", startLine = 1, endLine = 4, createdAt = Instant.now()
+                ),
+                SymbolRecord(
+                    id = 0, fileId = fileId, chunkId = calleeChunk.id, symbolType = SymbolType.FUNCTION,
+                    name = "callee", qualifiedName = "pkg.callee", signature = "PROCEDURE callee",
+                    language = "plsql", startLine = 6, endLine = 9, createdAt = Instant.now()
+                )
+            )
+        )
+
+        CrossFileLinkBuilder().rebuildForFile(fileId)
+
+        val callers = ContextRepository.traverseGraphReverse(
+            seedChunkIds = listOf(calleeChunk.id),
+            maxDepth = 2,
+            linkTypes = setOf("CALLS", "DEPENDS_ON", "MODIFIES")
+        )
+        assertTrue(
+            callers.any { it.chunkId == callerChunk.id && it.depth == 1 },
+            "parameterless caller must be found at depth 1: ${callers.map { it.chunkId to it.depth }}"
+        )
+    }
+
+    @Test
     fun `rebuildForFiles builds links for multiple files in one batch`() {
         // Two source files, each calling/importing a symbol defined in a shared target file.
         val target = insertFile("src/Target.kt")


### PR DESCRIPTION
Follow-up to #48 closing the exact root cause the user pinned: `get_impact_radius` returned 0 callers for a procedure invoked as `name;` (no parens), and the inbound edges it *did* show were spec-declaration→body, not real callers.

1. **Parameterless calls** — PL/SQL calls a no-arg procedure without parens (`process_load_confirmation_main;`). The extractor only matched `name(`. Added `extractParenlessCallTokens` for `SQL_STATEMENT` chunks: a whole-statement `name;`/`pkg.name;` is a call, excluding statement keywords (`NULL;`/`RETURN;`/`END name;`/…) and assignments.
2. **No more spec→body false edges** — `looksLikeDeclaration` was broken (matched the token inside the prefix, where it never is → always false), and `PROCEDURE/FUNCTION/TRIGGER` weren't declaration keywords. So `PROCEDURE foo(...);` in a `.pks` spec produced a bogus CALLS edge into the body. Fixed the prefix match and added the PL/SQL keywords — declarations no longer become call tokens. (Chose to not generate the false edge rather than tag a new linkType.)

Regression test: A calls parameterless `B;` → reverse traversal from B returns A at depth 1.

Needs a reindex to take effect (the graph is built at indexing time).
🤖 Generated with [Claude Code](https://claude.com/claude-code)