### PR TITLE
plsql: separate forward declarations from definitions (chunks + symbols)

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/chunking/SqlChunker.kt
+++ b/src/main/kotlin/com/orchestrator/context/chunking/SqlChunker.kt
@@ -45,6 +45,10 @@ class SqlChunker(
         """^\s*(?:(?:MEMBER|STATIC|MAP|ORDER|FINAL|OVERRIDING|CONSTRUCTOR)\s+)*(PROCEDURE|FUNCTION)\s+("?[\w${'$'}#]+"?)""",
         RegexOption.IGNORE_CASE
     )
+    // `IS`/`AS` opens a sub-program body — its presence (before a `;`) marks a definition vs a
+    // forward declaration. Bounds how far the signature scan looks ahead.
+    private val isAsKeywordRegex = Regex("""\b(?:IS|AS)\b""", RegexOption.IGNORE_CASE)
+    private val MAX_SIGNATURE_LINES = 60
 
     override fun chunk(content: String, filePath: String): List<Chunk> {
         if (content.isBlank()) return emptyList()
@@ -73,58 +77,119 @@ class SqlChunker(
     }
 
     /**
-     * Break a PACKAGE / PACKAGE BODY (or TYPE BODY) into a header chunk plus one chunk per member
-     * sub-program. A member starts at a top-level `PROCEDURE`/`FUNCTION` (depth 0, i.e. not inside
-     * another member's BEGIN..END body) and runs until the next member start or the package end.
-     * Returns the package as a single piece if no members are found (e.g. a thin package spec).
+     * Break a PACKAGE / PACKAGE BODY (or TYPE BODY) into a header chunk plus one chunk per member.
+     *
+     * Crucially distinguishes a sub-program *definition* (`PROCEDURE name(...) IS ... BEGIN ... END
+     * name;` — has a body) from a *forward declaration* (`PROCEDURE name(...);` — ends at `;`, no
+     * body). In a package body Oracle lists forward declarations first, then the bodies; treating a
+     * forward declaration as its own member produced tiny mislabelled chunks and made the symbol for
+     * a procedure point at its forward declaration instead of its real body.
+     *
+     * Package body: one chunk per *definition* (start → just before the next definition); forward
+     * declarations and package-level globals fold into the header. Package spec (no definitions):
+     * one chunk per declaration so the public API stays individually searchable.
      */
     private fun splitPackageMembers(statement: SqlStatement): List<LabeledPiece> {
         val lines = statement.text.split("\n")
         val packageLabel = extractLabel(statement.text.trim())
+        val base = statement.startLine
 
-        // Find member-start line indices that sit at package level (BEGIN/END depth 0).
-        val starts = mutableListOf<Pair<Int, String>>() // index to "PROCEDURE name" / "FUNCTION name"
+        // Top-level (BEGIN/END depth 0) sub-program *definitions* — forward declarations excluded.
+        val defStarts = mutableListOf<Pair<Int, String>>()
         var depth = 0
         for ((i, line) in lines.withIndex()) {
             val upper = line.uppercase(Locale.US)
             if (depth == 0) {
-                memberStartRegex.find(line)?.let { m ->
+                val m = memberStartRegex.find(line)
+                if (m != null && isDefinitionAt(lines, i)) {
                     val kind = m.groupValues[1].uppercase(Locale.US)
                     val name = m.groupValues[2].trim('"')
-                    starts += i to "$kind $name"
+                    defStarts += i to "$kind $name"
                 }
             }
             if (beginRegex.containsMatchIn(upper)) depth += 1
             if (blockEndRegex.containsMatchIn(upper)) depth = (depth - 1).coerceAtLeast(0)
         }
 
-        if (starts.isEmpty()) {
-            return listOf(LabeledPiece(packageLabel, statement.text, statement.startLine, statement.endLine))
+        if (defStarts.isEmpty()) {
+            // No bodies → package spec (or a thin package): split each declaration into its own chunk.
+            return splitDeclarations(lines, base, packageLabel, statement)
         }
 
         val pieces = mutableListOf<LabeledPiece>()
-        val base = statement.startLine
 
-        // Header: package declaration + package-level globals, up to the first member.
-        val firstStart = starts.first().first
-        if (firstStart > 0) {
-            val headerText = lines.subList(0, firstStart).joinToString("\n").trimEnd()
+        // Header: package declaration, globals and forward declarations, up to the first definition.
+        val firstDef = defStarts.first().first
+        if (firstDef > 0) {
+            val headerText = lines.subList(0, firstDef).joinToString("\n").trimEnd()
             if (headerText.isNotBlank()) {
-                pieces += LabeledPiece(packageLabel, headerText, base, base + firstStart - 1)
+                pieces += LabeledPiece(packageLabel, headerText, base, base + firstDef - 1)
             }
         }
 
-        // Each member spans from its start line to just before the next member start (last → end).
-        for ((k, start) in starts.withIndex()) {
-            val startIdx = start.first
-            val endIdx = if (k + 1 < starts.size) starts[k + 1].first - 1 else lines.lastIndex
+        // Each definition is one chunk: its start line to just before the next definition.
+        for ((k, def) in defStarts.withIndex()) {
+            val startIdx = def.first
+            val endIdx = if (k + 1 < defStarts.size) defStarts[k + 1].first - 1 else lines.lastIndex
             val text = lines.subList(startIdx, endIdx + 1).joinToString("\n").trimEnd()
             if (text.isNotBlank()) {
-                pieces += LabeledPiece(start.second, text, base + startIdx, base + endIdx)
+                pieces += LabeledPiece(def.second, text, base + startIdx, base + endIdx)
             }
         }
 
         return pieces
+    }
+
+    /** Split a package spec into one chunk per declared member (no bodies present). */
+    private fun splitDeclarations(
+        lines: List<String>,
+        base: Int,
+        packageLabel: String,
+        statement: SqlStatement
+    ): List<LabeledPiece> {
+        val starts = mutableListOf<Pair<Int, String>>()
+        var depth = 0
+        for ((i, line) in lines.withIndex()) {
+            val upper = line.uppercase(Locale.US)
+            if (depth == 0) {
+                memberStartRegex.find(line)?.let { m ->
+                    starts += i to "${m.groupValues[1].uppercase(Locale.US)} ${m.groupValues[2].trim('"')}"
+                }
+            }
+            if (beginRegex.containsMatchIn(upper)) depth += 1
+            if (blockEndRegex.containsMatchIn(upper)) depth = (depth - 1).coerceAtLeast(0)
+        }
+        if (starts.isEmpty()) {
+            return listOf(LabeledPiece(packageLabel, statement.text, statement.startLine, statement.endLine))
+        }
+        val pieces = mutableListOf<LabeledPiece>()
+        val firstStart = starts.first().first
+        if (firstStart > 0) {
+            val headerText = lines.subList(0, firstStart).joinToString("\n").trimEnd()
+            if (headerText.isNotBlank()) pieces += LabeledPiece(packageLabel, headerText, base, base + firstStart - 1)
+        }
+        for ((k, start) in starts.withIndex()) {
+            val startIdx = start.first
+            val endIdx = if (k + 1 < starts.size) starts[k + 1].first - 1 else lines.lastIndex
+            val text = lines.subList(startIdx, endIdx + 1).joinToString("\n").trimEnd()
+            if (text.isNotBlank()) pieces += LabeledPiece(start.second, text, base + startIdx, base + endIdx)
+        }
+        return pieces
+    }
+
+    /**
+     * True if the sub-program at [startIdx] is a *definition* (has an `IS`/`AS` body) rather than a
+     * *forward declaration* (the signature ends at `;` before any `IS`/`AS`). Scans the signature
+     * forward a bounded number of lines: an `IS`/`AS` keyword ⇒ definition; a `;` first ⇒ declaration.
+     */
+    private fun isDefinitionAt(lines: List<String>, startIdx: Int): Boolean {
+        val limit = minOf(startIdx + MAX_SIGNATURE_LINES, lines.size)
+        for (j in startIdx until limit) {
+            val code = lines[j].substringBefore("--")
+            if (isAsKeywordRegex.containsMatchIn(code)) return true
+            if (code.trimEnd().endsWith(";")) return false
+        }
+        return true // default to definition: keep the body as its own member rather than lose it
     }
 
     private fun splitStatements(content: String): List<SqlStatement> {

--- a/src/main/kotlin/com/orchestrator/context/indexing/SymbolIndexBuilder.kt
+++ b/src/main/kotlin/com/orchestrator/context/indexing/SymbolIndexBuilder.kt
@@ -101,6 +101,7 @@ class SymbolIndexBuilder(
         """^\s*(?:(?:MEMBER|STATIC|MAP|ORDER|FINAL|OVERRIDING|CONSTRUCTOR)\s+)*(?:PROCEDURE|FUNCTION)\s+("?[\w${'$'}#]+"?)""",
         RegexOption.IGNORE_CASE
     )
+    private val plsqlIsAsRegex = Regex("""\b(?:IS|AS)\b""", RegexOption.IGNORE_CASE)
 
     /**
      * Extract Oracle PL/SQL symbols: the PACKAGE/TYPE itself, standalone CREATE PROCEDURE/FUNCTION,
@@ -110,9 +111,20 @@ class SymbolIndexBuilder(
      */
     private fun extractPlSql(code: String, fileId: Long, language: String): List<SymbolRecord> {
         val symbols = mutableListOf<SymbolRecord>()
+        val lines = code.split("\n")
         var packageName: String? = null
 
-        code.split("\n").forEachIndexed { idx, line ->
+        // Pass 1: names that have a *definition* (an IS/AS body) in this file. A package body lists
+        // forward declarations (`PROCEDURE p;`) before the bodies; the symbol for `p` must point at
+        // its body, so we suppress the forward declaration whenever a definition exists.
+        val definedNames = HashSet<String>()
+        for ((idx, line) in lines.withIndex()) {
+            plsqlMemberRegex.find(line)?.let { m ->
+                if (isPlsqlDefinition(lines, idx)) definedNames += m.groupValues[1].trim('"').lowercase(Locale.US)
+            }
+        }
+
+        lines.forEachIndexed { idx, line ->
             val lineNumber = idx + 1
             val trimmed = line.trim()
             if (trimmed.isEmpty() || trimmed.startsWith("--")) return@forEachIndexed
@@ -148,6 +160,10 @@ class SymbolIndexBuilder(
 
             plsqlMemberRegex.find(line)?.let { m ->
                 val name = m.groupValues[1].trim('"')
+                // Skip a forward declaration when a real definition of the same name exists here.
+                if (!isPlsqlDefinition(lines, idx) && name.lowercase(Locale.US) in definedNames) {
+                    return@forEachIndexed
+                }
                 val qualified = packageName?.let { "$it.$name" } ?: name
                 symbols += symbol(
                     fileId = fileId,
@@ -161,6 +177,18 @@ class SymbolIndexBuilder(
             }
         }
         return symbols
+    }
+
+    /** True if the member at [idx] has an IS/AS body (definition) rather than ending at `;` (a
+     * forward declaration). Mirrors SqlChunker.isDefinitionAt. */
+    private fun isPlsqlDefinition(lines: List<String>, idx: Int): Boolean {
+        val limit = minOf(idx + 60, lines.size)
+        for (j in idx until limit) {
+            val code = lines[j].substringBefore("--")
+            if (plsqlIsAsRegex.containsMatchIn(code)) return true
+            if (code.trimEnd().endsWith(";")) return false
+        }
+        return true
     }
 
     private fun extractKotlin(code: String, fileId: Long, language: String): List<SymbolRecord> {

--- a/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerPackageTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/chunking/SqlChunkerPackageTest.kt
@@ -78,6 +78,46 @@ class SqlChunkerPackageTest {
     }
 
     @Test
+    fun `forward declarations fold into header and the body is the labelled chunk`() {
+        val sql = """
+            CREATE OR REPLACE PACKAGE BODY pkg AS
+              PROCEDURE process_main;
+              PROCEDURE helper;
+
+              PROCEDURE helper IS
+              BEGIN
+                NULL;
+              END helper;
+
+              PROCEDURE process_main IS
+              BEGIN
+                helper;
+              END process_main;
+            END pkg;
+            /
+        """.trimIndent()
+
+        val chunks = chunker.chunk(sql, "pkg.pkb")
+
+        // process_main appears exactly once — as its body, not the forward declaration.
+        val mains = chunks.filter { it.summary == "PROCEDURE process_main" }
+        assertEquals(1, mains.size, "process_main must be one chunk (its body), got ${chunks.map { it.summary }}")
+        val main = mains.single()
+        assertTrue(main.content.contains("helper;"), "the body chunk must contain the procedure body")
+        assertTrue(main.content.contains("END process_main"), "body chunk must span to its END")
+        assertTrue(main.startLine!! > 4, "body chunk must start at the definition (line >4), not the forward decl")
+
+        // The forward declarations live in the header chunk, not their own labelled member chunks.
+        val header = chunks.first()
+        assertTrue(
+            header.content.contains("PROCEDURE process_main;") && header.content.contains("PROCEDURE helper;"),
+            "forward declarations must fold into the header"
+        )
+        assertTrue(chunks.none { it.summary == "PROCEDURE helper" && !it.content.contains("BEGIN") },
+            "a forward declaration must not become its own member chunk")
+    }
+
+    @Test
     fun `non-package sql is unaffected`() {
         val sql = "CREATE TABLE users (id INT PRIMARY KEY);"
         val chunks = chunker.chunk(sql, "schema.sql")

--- a/src/test/kotlin/com/orchestrator/context/indexing/SymbolIndexBuilderTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/indexing/SymbolIndexBuilderTest.kt
@@ -275,4 +275,43 @@ class SymbolIndexBuilderTest {
         val fn = symbols.find { it.symbolType == SymbolType.FUNCTION && it.name == "get_qty" }
         assertTrue(fn != null, "function should be extracted")
     }
+
+    @Test
+    fun `PL-SQL symbol points at the body, not the forward declaration`() = runBlocking {
+        val plsql = """
+            CREATE OR REPLACE PACKAGE BODY pkg AS
+              PROCEDURE process_main;
+              PROCEDURE helper;
+
+              PROCEDURE helper IS
+              BEGIN
+                NULL;
+              END helper;
+
+              PROCEDURE process_main IS
+              BEGIN
+                helper;
+              END process_main;
+            END pkg;
+            /
+        """.trimIndent()
+
+        val sourceFile = tempDir.resolve("pkg.pkb")
+        Files.writeString(sourceFile, plsql)
+        ContextDatabase.transaction { conn ->
+            conn.prepareStatement(
+                """
+                INSERT INTO file_state (file_id, rel_path, abs_path, content_hash, size_bytes, mtime_ns, is_deleted)
+                VALUES (9, 'pkg.pkb', '/test/pkg.pkb', 'hash', 100, 1, FALSE)
+                """.trimIndent()
+            ).use { it.executeUpdate() }
+        }
+
+        val symbols = builder.indexFile(sourceFile, fileId = 9, language = "plsql")
+
+        val mains = symbols.filter { it.symbolType == SymbolType.FUNCTION && it.name == "process_main" }
+        assertEquals(1, mains.size, "exactly one process_main symbol (the body), not the forward decl: $mains")
+        // Body starts at the definition line (line 11 here, 1-based), not the forward decl (line 2).
+        assertTrue(mains.single().startLine!! > 4, "symbol must point at the body, not the forward declaration")
+    }
 }


### PR DESCRIPTION
**The blocker behind the empty PL/SQL call graph.** In a package body the forward declarations (`PROCEDURE p;`) are listed before the bodies. The chunker and symbol extractor treated every `PROCEDURE name` line as a member, so a procedure's *symbol* pointed at its forward declaration (a tiny mislabelled chunk) instead of its real body — nothing for a call to resolve to.

Distinguish a definition (`PROCEDURE name(...) IS ... BEGIN ... END name;`) from a forward declaration (`PROCEDURE name(...);`) by scanning the signature for `IS`/`AS` before a `;`.

- **SqlChunker**: a package body yields one chunk per *definition*; forward declarations + globals fold into the header. A spec (no definitions) still splits per declaration.
- **SymbolIndexBuilder**: a procedure's symbol is emitted at its definition; a forward declaration is suppressed when a definition of the same name exists in the file.

**Verified on the real deckers package**: `process_load_confirmation_main` is now a single chunk/symbol at its body (lines **6023-7673**), zero forward-decl-as-member chunks. This satisfies acceptance #1 and, combined with #48 (intra-file edges) + #49 (parameterless calls), unblocks #2: `xxd_shpcnf_main_prc` calls `process_load_confirmation_main;` → resolves to the body symbol → reverse traversal finds the caller.

Tests cover the body-vs-forward-decl split for both chunks and symbols. Needs a reindex to take effect.
🤖 Generated with [Claude Code](https://claude.com/claude-code)