### PR TITLE
graph: strip comments and strings before extracting call tokens

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilder.kt
+++ b/src/main/kotlin/com/orchestrator/context/indexing/CrossFileLinkBuilder.kt
@@ -109,15 +109,20 @@ class CrossFileLinkBuilder(
 
         val sourceRelPath = loadFileRelPath(conn, fileId)
         val isTestFile = sourceRelPath != null && looksLikeTestFile(sourceRelPath)
+        val language = loadFileLanguage(conn, fileId)
 
         val imports = loadImportSymbols(conn, fileId)
         val callTokensByChunk = sourceChunks.associate { chunk ->
+            // Strip comments and string literals first: a `name(` mentioned in a comment (e.g. an
+            // Oracle header `-- called from process_load_confirmation_main(...)`) or string must NOT
+            // create a phantom CALLS edge — that turned callees into "callers" in get_impact_radius.
+            val code = stripNonCode(chunk.content, language)
             // PL/SQL (SQL_STATEMENT chunks) calls parameterless procedures as bare `name;` with no
             // parens, which the `name(` regex misses — add those so intra-package callers are found.
             val tokens = if (chunk.kind == "SQL_STATEMENT") {
-                extractCallTokens(chunk.content) + extractParenlessCallTokens(chunk.content)
+                extractCallTokens(code) + extractParenlessCallTokens(code)
             } else {
-                extractCallTokens(chunk.content)
+                extractCallTokens(code)
             }
             chunk.chunkId to tokens.distinct()
         }
@@ -367,6 +372,78 @@ class CrossFileLinkBuilder(
             ps.setLong(1, fileId)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
         }
+
+    private fun loadFileLanguage(conn: Connection, fileId: Long): String? =
+        conn.prepareStatement("SELECT language FROM file_state WHERE file_id = ?").use { ps ->
+            ps.setLong(1, fileId)
+            ps.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
+        }
+
+    /**
+     * Remove comments and string literals so identifiers inside them don't become phantom call
+     * tokens. Newlines are preserved (parameterless-call detection works line by line); other
+     * stripped characters become spaces. Comment/string syntax is chosen by the file's language.
+     */
+    private fun stripNonCode(content: String, language: String?): String {
+        val style = commentStyleFor(language)
+        val sb = StringBuilder(content.length)
+        var i = 0
+        val n = content.length
+        while (i < n) {
+            val lc = style.lineComments.firstOrNull { content.startsWith(it, i) }
+            if (lc != null) {
+                while (i < n && content[i] != '\n') i++
+                continue
+            }
+            if (style.blockStart != null && content.startsWith(style.blockStart, i)) {
+                i += style.blockStart.length
+                while (i < n && !content.startsWith(style.blockEnd!!, i)) {
+                    if (content[i] == '\n') sb.append('\n')
+                    i++
+                }
+                i += if (i < n) style.blockEnd!!.length else 0
+                continue
+            }
+            val ch = content[i]
+            if (ch in style.stringDelims) {
+                val triple = style.tripleQuotes && i + 2 < n && content[i + 1] == ch && content[i + 2] == ch
+                i += if (triple) 3 else 1
+                while (i < n) {
+                    val cur = content[i]
+                    if (!style.sqlEscape && cur == '\\') { i = (i + 2).coerceAtMost(n); continue }
+                    if (triple) {
+                        if (i + 2 < n && content[i] == ch && content[i + 1] == ch && content[i + 2] == ch) { i += 3; break }
+                    } else if (cur == ch) {
+                        if (style.sqlEscape && i + 1 < n && content[i + 1] == ch) { i += 2; continue } // '' escape
+                        i++; break
+                    }
+                    if (cur == '\n') sb.append('\n')
+                    i++
+                }
+                sb.append(' ')
+                continue
+            }
+            sb.append(ch)
+            i++
+        }
+        return sb.toString()
+    }
+
+    private fun commentStyleFor(language: String?): CommentStyle = when (language?.lowercase(Locale.US)) {
+        "plsql", "sql", "pls", "pks", "pkb" -> CommentStyle(listOf("--"), "/*", "*/", setOf('\''), sqlEscape = true)
+        "python", "py" -> CommentStyle(listOf("#"), null, null, setOf('\'', '"'), tripleQuotes = true)
+        // c-family + kotlin/go/typescript/javascript (and unknown — a safe default).
+        else -> CommentStyle(listOf("//"), "/*", "*/", setOf('"', '\'', '`'))
+    }
+
+    private data class CommentStyle(
+        val lineComments: List<String>,
+        val blockStart: String?,
+        val blockEnd: String?,
+        val stringDelims: Set<Char>,
+        val tripleQuotes: Boolean = false,
+        val sqlEscape: Boolean = false
+    )
 
     private fun insertLinks(conn: Connection, links: List<LinkRow>) {
         if (links.isEmpty()) return

--- a/src/test/kotlin/com/orchestrator/context/indexing/CallDirectionTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/indexing/CallDirectionTest.kt
@@ -1,0 +1,70 @@
+package com.orchestrator.context.indexing
+
+import com.orchestrator.context.config.StorageConfig
+import com.orchestrator.context.domain.Chunk
+import com.orchestrator.context.domain.ChunkKind
+import com.orchestrator.context.domain.FileState
+import com.orchestrator.context.domain.SymbolRecord
+import com.orchestrator.context.domain.SymbolType
+import com.orchestrator.context.storage.ChunkRepository
+import com.orchestrator.context.storage.ContextDatabase
+import com.orchestrator.context.storage.FileStateRepository
+import com.orchestrator.context.storage.SymbolRepository
+import java.nio.file.Path
+import java.time.Instant
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalPathApi::class)
+class CallDirectionTest {
+    private lateinit var tempDir: Path
+
+    @BeforeTest fun setup() {
+        tempDir = createTempDirectory("calldir")
+        ContextDatabase.initialize(StorageConfig(dbPath = tempDir.resolve("c.duckdb").toString()))
+        ContextDatabase.withConnection { conn -> conn.createStatement().use {
+            it.executeUpdate("DELETE FROM links"); it.executeUpdate("DELETE FROM symbols")
+            it.executeUpdate("DELETE FROM chunks"); it.executeUpdate("DELETE FROM file_state")
+        } }
+    }
+    @AfterTest fun teardown() { ContextDatabase.shutdown(); tempDir.deleteRecursively() }
+
+    @Test fun `a name mentioned in a comment does not become a phantom caller`() {
+        val fileId = FileStateRepository.insert(FileState(0, "p.pkb", tempDir.resolve("p.pkb").toString(),
+            "h", 1, 1, "plsql", "code", null, Instant.now(), false)).id
+
+        // create_delivery [1-2], assign_detail [4-5], seed (calls both, with parens) [7-11], xxd (calls seed parenless) [13-16]
+        fun ins(ord: Int, s: Int, e: Int, content: String) = ChunkRepository.insert(
+            Chunk(0, fileId, ord, ChunkKind.SQL_STATEMENT, s, e, 20, content, "PROCEDURE", Instant.now()))
+        val cCreate = ins(0, 1, 3, "PROCEDURE create_delivery IS\n-- invoked by process_load_confirmation_main(p_x)\nBEGIN NULL; END create_delivery;")
+        val cAssign = ins(1, 4, 5, "PROCEDURE assign_detail_to_delivery IS\nBEGIN NULL; END assign_detail_to_delivery;")
+        val cSeed = ins(2, 7, 11, "PROCEDURE process_load_confirmation_main IS\nBEGIN\n  create_delivery(p_x);\n  assign_detail_to_delivery(p_y);\nEND process_load_confirmation_main;")
+        val cXxd = ins(3, 13, 16, "PROCEDURE xxd_shpcnf_main_prc IS\nBEGIN\n  process_load_confirmation_main;\nEND xxd_shpcnf_main_prc;")
+
+        SymbolRepository.replaceForFile(fileId, listOf(
+            sym(fileId, cCreate.id, "create_delivery", 1), sym(fileId, cAssign.id, "assign_detail_to_delivery", 4),
+            sym(fileId, cSeed.id, "process_load_confirmation_main", 7), sym(fileId, cXxd.id, "xxd_shpcnf_main_prc", 13)))
+
+        CrossFileLinkBuilder().rebuildForFile(fileId)
+
+        // create_delivery's body only *mentions* the seed in a comment; the seed actually calls
+        // create_delivery and assign_detail. Reverse traversal (callers of the seed) must therefore
+        // return ONLY xxd — not the callees, and not the comment-mentioning create_delivery.
+        val callers = com.orchestrator.context.ContextRepository
+            .traverseGraphReverse(listOf(cSeed.id), 3, linkTypes = setOf("CALLS", "DEPENDS_ON", "MODIFIES"))
+            .map { it.chunkId }
+            .toSet()
+
+        assertTrue(cXxd.id in callers, "the real caller xxd must be present")
+        assertTrue(cCreate.id !in callers, "a callee mentioned in a comment must not be a caller")
+        assertTrue(cAssign.id !in callers, "callees must not appear as callers")
+    }
+
+    private fun sym(fileId: Long, chunkId: Long, name: String, line: Int) = SymbolRecord(
+        0, fileId, chunkId, SymbolType.FUNCTION, name, "p.$name", "PROCEDURE $name", "plsql", line, line + 1, Instant.now())
+}


### PR DESCRIPTION
**Bug #3**: `get_impact_radius` returned callees as "callers" (false-positive blast radius). The reverse traversal is strictly inbound and **correct** — the real cause is **phantom CALLS edges**.

`extractCallTokens` ran on raw chunk text, so a `name(` inside a comment or string created a real edge. Oracle bodies routinely have headers like `-- called from process_load_confirmation_main(...)`, so a callee that merely *mentions* the seed in a comment got a `callee→seed` edge and surfaced as a caller.

**Fix**: strip comments + string literals (language-aware) before tokenising; newlines preserved so parameterless-call detection still works.

Reproduced first (a callee mentioning the seed in a comment appeared as a caller), then fixed; regression test asserts reverse traversal returns only the real caller.

**Acceptance**: `get_impact_radius(process_load_confirmation_main)` now returns exactly `xxd_shpcnf_main_prc` (and transitive callers), not `create_delivery`/`assign_detail_to_delivery`. Needs a reindex.
🤖 Generated with [Claude Code](https://claude.com/claude-code)