### PR TITLE
mcp: impact_radius metadata-only mode + graph edge counts in stats

### DIFF
--- a/src/main/kotlin/com/orchestrator/mcp/McpServerImpl.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/McpServerImpl.kt
@@ -1493,6 +1493,11 @@ class McpServerImpl(
             put("chunks", JsonPrimitive(result.storage.chunks))
             put("embeddings", JsonPrimitive(result.storage.embeddings))
             put("totalSizeBytes", JsonPrimitive(result.storage.totalSizeBytes))
+            // Graph edges, so a caller can confirm a rebuild populated the call graph.
+            put("links", JsonPrimitive(result.storage.links))
+            put("linksByType", buildJsonObject {
+                result.storage.linksByType.forEach { (type, count) -> put(type, JsonPrimitive(count)) }
+            })
         })
         put("languageDistribution", buildJsonArray {
             result.languageDistribution.forEach { stat ->
@@ -3398,7 +3403,8 @@ class McpServerImpl(
             includeTests = o.bool("includeTests") ?: true,
             tokenBudget = o.int("tokenBudget") ?: 8_000,
             maxImpactResults = o.int("maxImpactResults") ?: 200,
-            maxTestResults = o.int("maxTestResults") ?: 100
+            maxTestResults = o.int("maxTestResults") ?: 100,
+            bodies = o.bool("bodies") ?: true
         )
     }
 

--- a/src/main/kotlin/com/orchestrator/mcp/tools/GetContextStatsTool.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/tools/GetContextStatsTool.kt
@@ -26,7 +26,11 @@ class GetContextStatsTool(
         val files: Long,
         val chunks: Long,
         val embeddings: Long,
-        val totalSizeBytes: Long
+        val totalSizeBytes: Long,
+        // Graph edges, total and per link_type (CALLS/DEPENDS_ON/MODIFIES/COVERS). Lets a caller see
+        // that a rebuild actually populated the call graph, not just chunks/embeddings.
+        val links: Long,
+        val linksByType: Map<String, Long>
     )
 
     data class LanguageStat(
@@ -92,7 +96,14 @@ class GetContextStatsTool(
                     rs.getLong(1)
                 }
             }
-            StorageStats(files = files, chunks = chunks, embeddings = embeddings, totalSizeBytes = totalSize)
+            val linksByType = LinkedHashMap<String, Long>()
+            conn.prepareStatement("SELECT link_type, COUNT(*) FROM links GROUP BY link_type ORDER BY link_type").use { ps ->
+                ps.executeQuery().use { rs -> while (rs.next()) linksByType[rs.getString(1) ?: "UNKNOWN"] = rs.getLong(2) }
+            }
+            StorageStats(
+                files = files, chunks = chunks, embeddings = embeddings, totalSizeBytes = totalSize,
+                links = linksByType.values.sum(), linksByType = linksByType
+            )
         }
 
         val languageDistribution = ContextDatabase.withConnection { conn ->

--- a/src/main/kotlin/com/orchestrator/mcp/tools/GetImpactRadiusTool.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/tools/GetImpactRadiusTool.kt
@@ -39,7 +39,13 @@ class GetImpactRadiusTool(
         val includeTests: Boolean = true,
         val tokenBudget: Int = 8_000,
         val maxImpactResults: Int = 200,
-        val maxTestResults: Int = 100
+        val maxTestResults: Int = 100,
+        /**
+         * When false, return metadata only (label, file, lines, depth, linkType, role) with empty
+         * chunk text. Impact analysis usually only needs the shape of the graph; full bodies blow
+         * the token budget, so this lets a caller get the whole radius cheaply.
+         */
+        val bodies: Boolean = true
     )
 
     data class ImpactChunk(
@@ -159,6 +165,28 @@ class GetImpactRadiusTool(
                 else -> { role = "test"; edge = testById[id] }
             }
 
+            // Metadata-only mode: emit the full radius with empty bodies and no token budgeting, so
+            // a caller can see the whole graph without blowing the context window.
+            if (!params.bodies) {
+                return@mapNotNull ImpactChunk(
+                    chunkId = chunk.id,
+                    filePath = data.filePath,
+                    relativePath = data.relativePath,
+                    language = data.language,
+                    startLine = chunk.lineSpan?.first,
+                    endLine = chunk.lineSpan?.last,
+                    label = chunk.summary,
+                    kind = chunk.kind.name,
+                    text = "",
+                    tokenEstimate = tokens,
+                    role = role,
+                    depth = edge?.depth,
+                    linkType = edge?.linkType,
+                    propagatedScore = edge?.linkScore,
+                    droppedFromBudget = false
+                )
+            }
+
             val overBudget = budget > 0 && tokensUsed + tokens > budget && role != "seed"
             if (overBudget) {
                 dropped++
@@ -259,6 +287,7 @@ class GetImpactRadiusTool(
             },
             "maxDepth":         { "type": "integer", "minimum": 1, "default": 2 },
             "includeTests":     { "type": "boolean", "default": true },
+            "bodies":           { "type": "boolean", "default": true, "description": "false = metadata only (label/file/lines/depth/linkType), empty bodies, no token budget" },
             "tokenBudget":      { "type": "integer", "minimum": 0, "default": 8000 },
             "maxImpactResults": { "type": "integer", "minimum": 1, "default": 200 },
             "maxTestResults":   { "type": "integer", "minimum": 1, "default": 100 }

--- a/src/test/kotlin/com/orchestrator/mcp/tools/GetImpactRadiusToolTest.kt
+++ b/src/test/kotlin/com/orchestrator/mcp/tools/GetImpactRadiusToolTest.kt
@@ -48,6 +48,30 @@ class GetImpactRadiusToolTest {
     }
 
     @Test
+    fun `bodies false returns metadata only with empty text and no budget drops`() {
+        val result = GetImpactRadiusTool().execute(
+            GetImpactRadiusTool.Params(
+                paths = listOf("src/Target.kt"),
+                maxDepth = 2,
+                tokenBudget = 1, // tiny budget that would drop bodies in normal mode
+                bodies = false
+            )
+        )
+
+        assertEquals(4, result.chunks.size, "full radius returned even with a tiny budget")
+        assertEquals(0, result.droppedDueToBudget, "no budget dropping in metadata-only mode")
+        result.chunks.forEach { c ->
+            assertEquals("", c.text, "bodies=false must return empty text")
+            // Metadata is still present.
+            assertEquals(true, c.label != null || c.relativePath != null)
+        }
+        val byId = result.chunks.associateBy { it.chunkId }
+        assertEquals("impact", byId.getValue(200L).role)
+        assertEquals("CALLS", byId.getValue(200L).linkType)
+        assertEquals(1, byId.getValue(200L).depth)
+    }
+
+    @Test
     fun `whole-file change returns seed, impact, and tests`() {
         val result = GetImpactRadiusTool().execute(
             GetImpactRadiusTool.Params(


### PR DESCRIPTION
Two usability fixes requested after real PL/SQL review use.

1. **`get_impact_radius` `bodies` flag** (default `true`). `bodies=false` returns the whole radius as **metadata only** — `label, file, lines, depth, linkType, role` — with empty text and no token budgeting. Full bodies blew the context window on almost every call; impact analysis needs the graph shape, not the code. *(The most-requested usability fix.)*
2. **`get_context_stats` graph visibility**: now reports `links` (total edges) and `linksByType` (CALLS/DEPENDS_ON/MODIFIES/COVERS), so a caller can confirm a rebuild populated the call graph (stats previously showed only chunks/embeddings — which made it look like a rebuild hadn't applied).

Test covers `bodies=false` (full radius, empty text, no budget drops, metadata intact).
🤖 Generated with [Claude Code](https://claude.com/claude-code)