### PR TITLE
search: make the symbol provider robust (returned 0 in real PL/SQL use)

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/providers/SymbolContextProvider.kt
+++ b/src/main/kotlin/com/orchestrator/context/providers/SymbolContextProvider.kt
@@ -35,12 +35,18 @@ class SymbolContextProvider(
                     while (rs.next()) {
                         val chunkId = rs.getLong("chunk_id")
                         val symbolId = rs.getLong("symbol_id")
-                        val content = rs.getString("content") ?: continue
                         val summary = rs.getString("signature")
                         val name = rs.getString("name")
                         val qualified = rs.getString("qualified_name")
                         val symbolType = rs.getString("symbol_type") ?: "UNKNOWN"
                         val path = rs.getString("abs_path") ?: continue
+                        // A symbol with no attached chunk (rare) still surfaces, using its signature
+                        // or qualified name as text, instead of being silently dropped.
+                        val content = rs.getString("content")
+                            ?: summary
+                            ?: qualified
+                            ?: name
+                            ?: continue
                         val language = rs.getString("language") ?: rs.getString("file_language")
                         val chunkKind = rs.getString("kind")
                             ?.let { runCatching { ChunkKind.valueOf(it) }.getOrNull() }
@@ -166,8 +172,13 @@ class SymbolContextProvider(
         }
 
         if (scope.languages.isNotEmpty()) {
+            // Match on the FILE's language as well as the symbol's: the file's language is the
+            // authoritative one a query scopes by, and a symbol's stored language can lag behind it
+            // (e.g. a symbol indexed before the extension→language mapping was added). Filtering on
+            // s.language alone silently dropped every symbol in those files.
             val placeholders = scope.languages.joinToString(",") { "?" }
-            conditions += "s.language IN ($placeholders)"
+            conditions += "(s.language IN ($placeholders) OR f.language IN ($placeholders))"
+            scope.languages.forEach { params += it }
             scope.languages.forEach { params += it }
         }
 
@@ -185,15 +196,20 @@ class SymbolContextProvider(
                    s.start_line,
                    s.end_line,
                    s.language,
-                   c.chunk_id,
-                   c.kind,
-                   c.content,
-                   c.token_count,
+                   COALESCE(c.chunk_id, cl.chunk_id) AS chunk_id,
+                   COALESCE(c.kind, cl.kind) AS kind,
+                   COALESCE(c.content, cl.content) AS content,
+                   COALESCE(c.token_count, cl.token_count) AS token_count,
                    f.abs_path,
                    f.language AS file_language
             FROM symbols s
             JOIN file_state f ON f.file_id = s.file_id
-            LEFT JOIN chunks c ON c.file_id = s.file_id AND c.start_line <= COALESCE(s.start_line, c.start_line) AND c.end_line >= COALESCE(s.end_line, c.end_line)
+            -- Prefer the chunk the indexer already attached (s.chunk_id); fall back to line containment
+            -- only when it is missing, instead of relying solely on a fragile line join.
+            LEFT JOIN chunks c ON c.chunk_id = s.chunk_id
+            LEFT JOIN chunks cl ON s.chunk_id IS NULL AND cl.file_id = s.file_id
+                AND cl.start_line <= COALESCE(s.start_line, cl.start_line)
+                AND cl.end_line >= COALESCE(s.end_line, cl.end_line)
             WHERE $where
             LIMIT $fetchLimit
         """.trimIndent()

--- a/src/test/kotlin/com/orchestrator/context/providers/SymbolProviderPlsqlTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/providers/SymbolProviderPlsqlTest.kt
@@ -1,0 +1,79 @@
+package com.orchestrator.context.providers
+
+import com.orchestrator.context.chunking.SqlChunker
+import com.orchestrator.context.config.StorageConfig
+import com.orchestrator.context.domain.ContextScope
+import com.orchestrator.context.domain.FileState
+import com.orchestrator.context.domain.TokenBudget
+import com.orchestrator.context.indexing.SymbolIndexBuilder
+import com.orchestrator.context.storage.ChunkRepository
+import com.orchestrator.context.storage.ContextDatabase
+import com.orchestrator.context.storage.FileStateRepository
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.deleteRecursively
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalPathApi::class)
+class SymbolProviderPlsqlTest {
+    private lateinit var tempDir: Path
+    @BeforeTest fun s() { tempDir = createTempDirectory("symp"); ContextDatabase.initialize(StorageConfig(dbPath = tempDir.resolve("c.duckdb").toString()))
+        ContextDatabase.withConnection { c -> c.createStatement().use { it.executeUpdate("DELETE FROM links"); it.executeUpdate("DELETE FROM symbols"); it.executeUpdate("DELETE FROM chunks"); it.executeUpdate("DELETE FROM file_state") } } }
+    @AfterTest fun t() { ContextDatabase.shutdown(); tempDir.deleteRecursively() }
+
+    @Test fun `exact name returns the body chunk and tolerates a stale symbol language`() = runBlocking {
+        // Body package: forward decl of process_load_confirmation_main, plus its definition.
+        val body = """
+            CREATE OR REPLACE PACKAGE BODY xxd AS
+              PROCEDURE process_load_confirmation_main;
+              PROCEDURE process_load_confirmation_main IS
+              BEGIN
+                NULL;
+              END process_load_confirmation_main;
+            END xxd;
+            /
+        """.trimIndent()
+        // Spec (decommissioned monolith) with a forward declaration of a similar name.
+        val spec = "CREATE OR REPLACE PACKAGE old3pl AS\n  PROCEDURE process_load_confirmation;\nEND old3pl;\n/"
+
+        for ((rel, src, lang) in listOf(Triple("xxd.pkb", body, "plsql"), Triple("3pl.pks", spec, "plsql"))) {
+            val p = tempDir.resolve(rel); Files.writeString(p, src)
+            val fid = FileStateRepository.insert(FileState(0, rel, p.toString(), "h", 1, 1, lang, "code", null, Instant.now(), false)).id
+            val chunks = SqlChunker(overlapPercent = 15).chunk(src, rel).map { ChunkRepository.insert(it.copy(fileId = fid)) }
+            SymbolIndexBuilder().indexFile(p, fid, lang, chunks)
+        }
+
+        // A stale symbol whose own language is "sql" while its file is "plsql" must still match a
+        // ["plsql"] scope (the file's language is authoritative). Insert it directly.
+        ContextDatabase.withConnection { c ->
+            val fid = c.prepareStatement("SELECT file_id FROM file_state WHERE rel_path='xxd.pkb'").use { ps -> ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) } }
+            val cid = c.prepareStatement("SELECT chunk_id FROM chunks WHERE file_id=? ORDER BY ordinal DESC LIMIT 1").use { ps -> ps.setLong(1, fid); ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) } }
+            c.prepareStatement("INSERT INTO symbols (symbol_id, file_id, chunk_id, symbol_type, name, qualified_name, signature, language, start_line, end_line, created_at) VALUES (99999, ?, ?, 'FUNCTION', 'stale_lang_proc', 'xxd.stale_lang_proc', 'PROCEDURE stale_lang_proc', 'sql', 3, 3, CURRENT_TIMESTAMP)").use { ps -> ps.setLong(1, fid); ps.setLong(2, cid); ps.executeUpdate() }
+        }
+
+        val res = SymbolContextProvider().getContext(
+            "process_load_confirmation_main",
+            ContextScope(languages = setOf("plsql")),
+            TokenBudget(maxTokens = 8000)
+        )
+        // Exact name resolves to the definition body, in the target package file — not a forward decl.
+        assertTrue(res.isNotEmpty(), "symbol provider must return the body for an exact name")
+        val top = res.first()
+        assertTrue(top.filePath.endsWith("xxd.pkb"), "top hit must be the body file, not the spec: ${top.filePath}")
+        assertTrue(top.text.contains("process_load_confirmation_main"), "must return the body chunk")
+
+        val stale = SymbolContextProvider().getContext(
+            "stale_lang_proc",
+            ContextScope(languages = setOf("plsql")),
+            TokenBudget(maxTokens = 8000)
+        )
+        assertTrue(stale.isNotEmpty(), "a symbol with stale s.language=sql in a plsql file must still match a plsql scope")
+    }
+}


### PR DESCRIPTION
**Point 2**: the SYMBOL provider returned 0 snippets on every query, even though the **call graph works** (it queries the same symbols table) — so the symbols exist; the provider's extra filters dropped them. Two fragilities fixed:

- **Language filter** used only `s.language`. A symbol's stored language can lag the file's (e.g. indexed before the `.pkb`→`plsql` mapping), so a `["plsql"]` scope silently excluded every symbol in those files. Now matches `f.language` too (the authoritative, query-facing language).
- **Chunk lookup** relied solely on a line-containment LEFT JOIN and skipped rows whose `content` came back NULL — one off-by-one dropped the symbol. Now joins on the indexer-attached `s.chunk_id` first, falls back to line containment only when absent, and surfaces a chunk-less symbol via its signature/name instead of dropping it.

Honest note: couldn't reproduce the exact 0 locally (a clean pipeline returns the body), so this hardens the two causes consistent with "graph works but provider empty". Test: exact name → definition body in the target package; a symbol with a stale `s.language` still matches its file's language scope.

Remaining from the user's list: ranking (definitions above forward-decls, target package above monolith) and per-query include/exclude paths — next.
🤖 Generated with [Claude Code](https://claude.com/claude-code)