### PR TITLE
search: de-rank forward declarations + apply excludePatterns to all providers

### DIFF
--- a/src/main/kotlin/com/orchestrator/mcp/tools/QueryContextTool.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/tools/QueryContextTool.kt
@@ -241,9 +241,14 @@ class QueryContextTool(
         // Sort by score and deduplicate
         val uniqueSnippets = deduplicateSnippets(allSnippets)
 
-        // Apply path/language boosts
-        val boostedSnippets = applyScoreBoosts(uniqueSnippets)
-        
+        // Drop excluded paths uniformly across every provider (scope.excludePatterns is only enforced
+        // by the semantic path otherwise, so symbol/full-text hits in e.g. a decommissioned monolith
+        // would still leak through).
+        val pathFiltered = applyPathExclusions(uniqueSnippets, scope)
+
+        // Apply path/language boosts, then push forward declarations below real definitions.
+        val boostedSnippets = deRankForwardDeclarations(applyScoreBoosts(pathFiltered))
+
         // Filter by minimum score threshold from config
         val filteredSnippets = boostedSnippets.filter { it.score >= config.query.minScoreThreshold }
         if (filteredSnippets.size < boostedSnippets.size) {
@@ -740,6 +745,49 @@ class QueryContextTool(
         }
     }
     
+    /** Remove snippets whose file path matches any scope.excludePatterns glob (all providers). */
+    private fun applyPathExclusions(snippets: List<ContextSnippet>, scope: ContextScope): List<ContextSnippet> {
+        if (scope.excludePatterns.isEmpty() || snippets.isEmpty()) return snippets
+        val regexes = scope.excludePatterns.map { globToRegex(it) }
+        val kept = snippets.filterNot { snippet -> regexes.any { it.containsMatchIn(snippet.filePath) } }
+        if (kept.size < snippets.size) {
+            log.debug("Excluded {} snippets via excludePatterns", snippets.size - kept.size)
+        }
+        return kept
+    }
+
+    private fun globToRegex(glob: String): Regex {
+        val sb = StringBuilder()
+        for (c in glob) {
+            when (c) {
+                '*' -> sb.append("[^/]*")
+                '?' -> sb.append("[^/]")
+                '.', '(', ')', '+', '^', '$', '{', '}', '[', ']', '\\', '|' -> sb.append('\\').append(c)
+                else -> sb.append(c)
+            }
+        }
+        return Regex(sb.toString(), RegexOption.IGNORE_CASE)
+    }
+
+    /**
+     * Push PL/SQL forward declarations (`PROCEDURE name(...);` — a bare signature, no body) below the
+     * real definition. A declaration is almost never what an identifier search wants; the body is.
+     */
+    private fun deRankForwardDeclarations(snippets: List<ContextSnippet>): List<ContextSnippet> {
+        if (snippets.isEmpty()) return snippets
+        return snippets.map { s ->
+            if (looksLikeForwardDeclaration(s)) s.copy(score = (s.score * FORWARD_DECL_PENALTY).coerceIn(0.0, 1.0)) else s
+        }
+    }
+
+    private fun looksLikeForwardDeclaration(snippet: ContextSnippet): Boolean {
+        if (snippet.kind != ChunkKind.SQL_STATEMENT) return false
+        val t = snippet.text.trim()
+        return forwardDeclStartRegex.containsMatchIn(t) &&
+            t.endsWith(";") &&
+            !beginKeywordRegex.containsMatchIn(t) // a real body has BEGIN; a forward declaration does not
+    }
+
     private fun applyScoreBoosts(snippets: List<ContextSnippet>): List<ContextSnippet> {
         if (snippets.isEmpty()) return emptyList()
         if (config.query.boosts.pathPrefixes.isEmpty() && config.query.boosts.languages.isEmpty()) {
@@ -1034,6 +1082,14 @@ class QueryContextTool(
         private const val LINK_TYPE_CALLS = "CALLS"
         private const val LINK_TYPE_DEPENDS_ON = "DEPENDS_ON"
         private const val LINK_TYPE_MODIFIES = "MODIFIES"
+
+        // Forward declarations are demoted but not removed (kept as a fallback if no body exists).
+        private const val FORWARD_DECL_PENALTY = 0.5
+        private val forwardDeclStartRegex = Regex(
+            """^\s*(?:CREATE\s+(?:OR\s+REPLACE\s+)?)?(?:(?:MEMBER|STATIC|MAP|ORDER|FINAL|OVERRIDING|CONSTRUCTOR)\s+)*(?:PROCEDURE|FUNCTION)\b""",
+            RegexOption.IGNORE_CASE
+        )
+        private val beginKeywordRegex = Regex("""\bBEGIN\b""", RegexOption.IGNORE_CASE)
 
         const val JSON_SCHEMA: String = """
         {

--- a/src/test/kotlin/com/orchestrator/mcp/tools/QueryContextToolTest.kt
+++ b/src/test/kotlin/com/orchestrator/mcp/tools/QueryContextToolTest.kt
@@ -416,6 +416,47 @@ class QueryContextToolTest {
         return persisted.id
     }
 
+    @Test
+    fun `definition ranks above forward declaration and excludePatterns drops the monolith`() {
+        // Real files on disk (query_context drops snippets whose files are missing).
+        val bodyPath = tempDir.resolve("pkg/target.pkb"); java.nio.file.Files.createDirectories(bodyPath.parent); java.nio.file.Files.writeString(bodyPath, "x")
+        val specPath = tempDir.resolve("old/3pl.pks"); java.nio.file.Files.createDirectories(specPath.parent); java.nio.file.Files.writeString(specPath, "x")
+
+        // Target package: a real definition (has a BEGIN body).
+        val bodyFile = insertFileStateAbsolute("pkg/target.pkb", bodyPath.toString(), "plsql")
+        insertChunk(500L, bodyFile, "PROCEDURE load_confirm_main IS\nBEGIN\n  NULL;\nEND load_confirm_main;", ChunkKind.SQL_STATEMENT)
+        insertSymbol(5001L, bodyFile, 500L, "load_confirm_main", "plsql")
+
+        // Decommissioned monolith: a forward declaration (signature only, no body).
+        val specFile = insertFileStateAbsolute("old/3pl.pks", specPath.toString(), "plsql")
+        insertChunk(600L, specFile, "PROCEDURE load_confirm_main(p_x NUMBER);", ChunkKind.SQL_STATEMENT)
+        insertSymbol(6001L, specFile, 600L, "load_confirm_main", "plsql")
+
+        val tool = QueryContextTool(config)
+
+        val ranked = tool.execute(QueryContextTool.Params(query = "load_confirm_main", providers = listOf("symbol")))
+        val top = ranked.hits.firstOrNull()
+        assertNotNull(top, "expected a symbol hit")
+        assertTrue(top.filePath.endsWith("target.pkb"), "the definition body must outrank the forward decl: ${ranked.hits.map { it.filePath to it.score }}")
+
+        val scoped = tool.execute(QueryContextTool.Params(query = "load_confirm_main", providers = listOf("symbol"), excludePatterns = listOf("3pl.*")))
+        assertTrue(scoped.hits.none { it.filePath.endsWith("3pl.pks") }, "excludePatterns must drop the monolith from symbol results")
+        assertTrue(scoped.hits.any { it.filePath.endsWith("target.pkb") }, "the target package survives the exclusion")
+    }
+
+    private fun insertSymbol(symbolId: Long, fileId: Long, chunkId: Long, name: String, language: String) {
+        ContextDatabase.withConnection { conn ->
+            conn.prepareStatement(
+                "INSERT INTO symbols (symbol_id, file_id, chunk_id, symbol_type, name, qualified_name, signature, language, start_line, end_line, created_at) " +
+                    "VALUES (?, ?, ?, 'FUNCTION', ?, ?, ?, ?, 1, 1, CURRENT_TIMESTAMP)"
+            ).use { ps ->
+                ps.setLong(1, symbolId); ps.setLong(2, fileId); ps.setLong(3, chunkId)
+                ps.setString(4, name); ps.setString(5, "pkg.$name"); ps.setString(6, "PROCEDURE $name")
+                ps.setString(7, language); ps.executeUpdate()
+            }
+        }
+    }
+
     private fun insertChunk(chunkId: Long, fileId: Long, content: String = "content", kind: ChunkKind = ChunkKind.CODE_BLOCK) {
         ChunkRepository.insert(
             Chunk(


### PR DESCRIPTION
**Point 1 + #5** for identifier search in a migration repo.

- **Forward declarations outranked the definition.** `query_context` now demotes a PL/SQL forward declaration (a bare `PROCEDURE name(...);` with no `BEGIN`) relative to the real definition, so an identifier search surfaces the **body**, not the spec stub. Penalised, not removed (still shown if no body exists).
- **`excludePatterns` leaked through non-semantic providers.** It was only enforced on the semantic path (`ContextRepository`), so symbol/full-text hits in a decommissioned monolith still appeared. Now applied uniformly as a **post-aggregation path filter** over every provider's results — so a query can exclude e.g. the old `3pl.*` package. (`includePaths` already works via the existing `paths` param.)

Test (symbol provider, no FTS dependency): the definition body outranks the forward declaration (0.98 vs 0.5), and `excludePatterns=["3pl.*"]` drops the monolith while the target package survives.

Note: a pre-existing full-text/FTS git-snippet test fails in the sandbox (DuckDB FTS extension), unrelated to this change — verified by reverting.

Query-time only — no reindex needed (rebuild JAR + restart).
🤖 Generated with [Claude Code](https://claude.com/claude-code)