### PR TITLE
search: truncate oversized matching chunks instead of dropping them

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/providers/FullTextContextProvider.kt
+++ b/src/main/kotlin/com/orchestrator/context/providers/FullTextContextProvider.kt
@@ -43,7 +43,19 @@ class FullTextContextProvider(
         for (snippet in candidates) {
             if (result.size >= maxResults) break
             val tokens = max(1, snippet.metadata["token_estimate"]?.toIntOrNull() ?: snippet.text.length / 4)
-            if (tokenBudget > 0 && tokensUsed + tokens > tokenBudget) continue
+            val remaining = if (tokenBudget > 0) tokenBudget - tokensUsed else Int.MAX_VALUE
+            if (tokenBudget > 0 && tokens > remaining) {
+                // Don't drop a literal match just because the chunk is large (e.g. a whole PL/SQL
+                // procedure body); include the top one truncated to fit so the term still surfaces.
+                if (result.isEmpty() && remaining > 0) {
+                    val maxChars = remaining * 4
+                    result += snippet.copy(
+                        text = snippet.text.take(maxChars) + "\n… [truncated]",
+                        metadata = snippet.metadata + ("truncated" to "true")
+                    )
+                }
+                continue
+            }
             tokensUsed += tokens
             result += snippet
         }

--- a/src/main/kotlin/com/orchestrator/context/providers/SymbolContextProvider.kt
+++ b/src/main/kotlin/com/orchestrator/context/providers/SymbolContextProvider.kt
@@ -104,8 +104,17 @@ class SymbolContextProvider(
 
         for (candidate in ordered) {
             if (snippets.size >= maxResults) break
-            if (tokenBudget > 0 && tokensUsed + candidate.tokensNeeded > tokenBudget) continue
-
+            val remaining = if (tokenBudget > 0) tokenBudget - tokensUsed else Int.MAX_VALUE
+            if (tokenBudget > 0 && candidate.tokensNeeded > remaining) {
+                // Do NOT silently drop a matching symbol because its chunk is large — for an exact
+                // name lookup that oversized body is exactly the result wanted (a 1600-line PL/SQL
+                // procedure is one ~20k-token chunk). Include the top match truncated to fit; once
+                // the budget is spent there is no room for more.
+                if (snippets.isEmpty() && remaining > 0) {
+                    snippets += candidate.truncatedTo(remaining).toSnippet(id)
+                }
+                break
+            }
             tokensUsed += candidate.tokensNeeded
             snippets += candidate.toSnippet(id)
         }
@@ -274,8 +283,16 @@ class SymbolContextProvider(
         val offsets: IntRange?,
         val symbolType: String,
         val score: Double,
-        val tokensNeeded: Int
+        val tokensNeeded: Int,
+        val truncated: Boolean = false
     ) {
+        /** A copy whose text is cut to ~maxTokens (head of the chunk — keeps the signature/start). */
+        fun truncatedTo(maxTokens: Int): SymbolCandidate {
+            val maxChars = (maxTokens.coerceAtLeast(1)) * 4
+            if (text.length <= maxChars) return this
+            return copy(text = text.substring(0, maxChars) + "\n… [truncated]", tokensNeeded = maxTokens, truncated = true)
+        }
+
         fun toSnippet(providerId: String): ContextSnippet {
             return ContextSnippet(
                 chunkId = chunkId,
@@ -294,7 +311,8 @@ class SymbolContextProvider(
                     "symbol_id" to symbolId.toString(),
                     "symbol_type" to symbolType,
                     "token_estimate" to tokensNeeded.toString(),
-                    "score" to "%.3f".format(score)
+                    "score" to "%.3f".format(score),
+                    "truncated" to truncated.toString()
                 )
             )
         }

--- a/src/main/kotlin/com/orchestrator/mcp/tools/QueryContextTool.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/tools/QueryContextTool.kt
@@ -598,8 +598,16 @@ class QueryContextTool(
             if (result.size >= limit) break
 
             val tokens = estimateTokens(snippet)
-            if (tokenBudget > 0 && tokensUsed + tokens > tokenBudget) {
-                continue // skip oversized snippet, try smaller ones below
+            val remaining = if (tokenBudget > 0) tokenBudget - tokensUsed else Int.MAX_VALUE
+            if (tokenBudget > 0 && tokens > remaining) {
+                // The top-ranked result is sometimes a single large chunk (e.g. a 1600-line PL/SQL
+                // procedure body for an exact-name query). Truncate it to fit rather than dropping it
+                // entirely — otherwise the very thing that was searched for disappears from results.
+                if (result.isEmpty() && remaining > 0) {
+                    result.add(truncateSnippet(snippet, remaining))
+                    tokensUsed += remaining
+                }
+                continue // smaller snippets below may still fit
             }
 
             tokensUsed += tokens
@@ -607,6 +615,15 @@ class QueryContextTool(
         }
 
         return result
+    }
+
+    private fun truncateSnippet(snippet: ContextSnippet, maxTokens: Int): ContextSnippet {
+        val maxChars = maxTokens.coerceAtLeast(1) * 4
+        if (snippet.text.length <= maxChars) return snippet
+        return snippet.copy(
+            text = snippet.text.substring(0, maxChars) + "\n… [truncated]",
+            metadata = snippet.metadata + ("truncated" to "true")
+        )
     }
 
     private fun mergeSources(a: String?, b: String?): String =

--- a/src/test/kotlin/com/orchestrator/context/providers/SymbolProviderPlsqlTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/providers/SymbolProviderPlsqlTest.kt
@@ -76,4 +76,29 @@ class SymbolProviderPlsqlTest {
         )
         assertTrue(stale.isNotEmpty(), "a symbol with stale s.language=sql in a plsql file must still match a plsql scope")
     }
+
+    @Test fun `a huge body chunk that exceeds the token budget is truncated, not dropped`() = runBlocking {
+        // A 1600-line PL/SQL procedure is one ~20k-token chunk. The symbol matches it but it exceeds
+        // the budget — it must be returned (truncated), not silently dropped to zero hits.
+        val rel = "big.pkb"
+        val p = tempDir.resolve(rel); Files.writeString(p, "x")
+        val fid = FileStateRepository.insert(FileState(0, rel, p.toString(), "h", 1, 1, "plsql", "code", null, Instant.now(), false)).id
+        val hugeBody = "PROCEDURE huge_proc IS\nBEGIN\n" + "  do_work(x);\n".repeat(6000) + "END huge_proc;"
+        val chunk = ChunkRepository.insert(
+            com.orchestrator.context.domain.Chunk(
+                id = 0, fileId = fid, ordinal = 0, kind = com.orchestrator.context.domain.ChunkKind.SQL_STATEMENT,
+                startLine = 1, endLine = 6003, tokenEstimate = hugeBody.length / 4,
+                content = hugeBody, summary = "PROCEDURE huge_proc", createdAt = Instant.now()
+            )
+        )
+        ContextDatabase.withConnection { c ->
+            c.prepareStatement("INSERT INTO symbols (symbol_id, file_id, chunk_id, symbol_type, name, qualified_name, signature, language, start_line, end_line, created_at) VALUES (88888, ?, ?, 'FUNCTION', 'huge_proc', 'big.huge_proc', 'PROCEDURE huge_proc', 'plsql', 1, 6003, CURRENT_TIMESTAMP)")
+                .use { ps -> ps.setLong(1, fid); ps.setLong(2, chunk.id); ps.executeUpdate() }
+        }
+
+        val res = SymbolContextProvider().getContext("huge_proc", ContextScope(languages = setOf("plsql")), TokenBudget(maxTokens = 4000))
+        assertTrue(res.isNotEmpty(), "an oversized matching symbol must be returned (truncated), not dropped to zero")
+        assertTrue(res.first().text.contains("huge_proc"), "the truncated head must still contain the procedure")
+        assertTrue(res.first().text.length < hugeBody.length, "the body must be truncated to fit the budget")
+    }
 }


### PR DESCRIPTION
**The real cause of "symbol.snippets=0 AND full_text.snippets=0 for an exact name"** (the user's sharp new clue): `process_load_confirmation_main` is literally in the file, but its **body is a single ~20k-token chunk** (a 1600-line PL/SQL procedure). Every stage that packs results under a token budget — `SymbolContextProvider`, `FullTextContextProvider`, and `QueryContextTool.applyBudgetAndLimit` — did `continue` (skip) when a chunk exceeded the budget. So the one match that was searched for vanished, leaving only `semantic` (which then surfaced a similarly-named procedure from the old monolith).

**Fix**: when the top-ranked match is too large to fit, **truncate** its text to the remaining budget (keeping the head — signature + start of body) and mark it `truncated`, instead of dropping it. Applied in all three places.

Test: an oversized matching symbol is returned truncated (head still contains the procedure), not dropped to zero.

**Acceptance**: `query_context("process_load_confirmation_main")` now surfaces the body chunk (truncated to the budget) with `symbol.snippets > 0`. Query-time — no reindex; rebuild JAR + restart. (Note: a pre-existing full-text/FTS git-snippet test fails in the sandbox, unrelated — verified by reverting.)
🤖 Generated with [Claude Code](https://claude.com/claude-code)