### PR TITLE
search: keep the most-relevant match in MMR even if it exceeds the budget

### DIFF
--- a/src/main/kotlin/com/orchestrator/context/search/MmrReranker.kt
+++ b/src/main/kotlin/com/orchestrator/context/search/MmrReranker.kt
@@ -51,8 +51,13 @@ class MmrReranker(
             return tokensUsed + tokens <= availableTokens && tokens > 0
         }
 
-        // Select the highest relevance candidate that fits the budget as the seed.
-        val seed = candidates.firstOrNull { fitsBudget(it) } ?: return emptyList()
+        // Seed with the single most-relevant candidate — even if it alone exceeds the budget.
+        // An exact-name match is often one huge chunk (e.g. a 1600-line PL/SQL procedure body);
+        // dropping it for being oversized and substituting a smaller, less-relevant neighbour is
+        // precisely how an exact-name query loses its real answer. Downstream truncation trims the
+        // oversized seed to fit. Lower-relevance oversized candidates are still dropped in the loop
+        // below, so the budget is still honoured for everything except the top hit.
+        val seed = candidates.first()
         selected += seed
         tokensUsed += tokenCounts[seed] ?: 0
         candidates.remove(seed)

--- a/src/test/kotlin/com/orchestrator/context/search/MmrRerankerTest.kt
+++ b/src/test/kotlin/com/orchestrator/context/search/MmrRerankerTest.kt
@@ -58,6 +58,26 @@ class MmrRerankerTest {
         assertEquals(1L, reranked.first().chunk.id)
     }
 
+    @Test
+    fun `the most relevant candidate survives even when it alone exceeds the budget`() {
+        // An exact-name match whose body is one huge chunk (e.g. a 1600-line PL/SQL procedure).
+        // It is the most relevant hit but far exceeds the token budget. MMR must NOT silently drop
+        // it and substitute smaller, less-relevant forward declarations — that is exactly how an
+        // exact-name query loses its real answer. Downstream truncation trims the body to fit.
+        val hugeBody = "PROCEDURE process_load_confirmation_main IS BEGIN do_work; END;\n".repeat(2000)
+        // Symbol/full-text hits have no stored embedding → zero vector (mirrors production).
+        val body = scoredChunk(id = 1, score = 1.0f, vector = floatArrayOf(0f, 0f), content = hugeBody)
+        val forwardA = scoredChunk(id = 2, score = 0.40f, vector = floatArrayOf(1f, 0f), content = "PROCEDURE forward_a;")
+        val forwardB = scoredChunk(id = 3, score = 0.35f, vector = floatArrayOf(0f, 1f), content = "PROCEDURE forward_b;")
+
+        val budget = TokenBudget(maxTokens = 4000, reserveForPrompt = 0)
+        val reranked = reranker.rerank(listOf(body, forwardA, forwardB), lambda = 0.5, budget = budget)
+
+        assertTrue(reranked.isNotEmpty(), "the oversized top-relevance match must not be dropped to zero")
+        assertEquals(1L, reranked.first().chunk.id,
+            "the exact-name body must rank first, not the small forward declarations")
+    }
+
     private fun scoredChunk(
         id: Long,
         score: Float,


### PR DESCRIPTION
**Progress confirmed by the user**: after the previous fix, `symbol` and `full_text` finally return 1 snippet each for the exact name `process_load_confirmation_main`. But the body still never appeared in `hits` — `returnedHits(3)` were all semantic forward declarations from a decommissioned package, and `totalHits(5) − returnedHits(3) = symbol(1) + full_text(1)` pointed exactly at the missing two.

**Root cause — one stage past PR #57**: `MmrReranker.rerank` enforces the token budget by *silently dropping* any candidate that doesn't fit (`fitsBudget`). The exact-name match is a single ~20k-token chunk (a 1600-line PL/SQL procedure body) that can never fit a ~4k budget, so MMR removed it **before** the final budget pass could truncate it — leaving only the small, less-relevant semantic neighbours. Pagination couldn't recover it because it was already gone from the MMR output.

**Not a fusion bug**: `ReciprocalRankFusion.fuse` already merges `symbol`/`full_text` into the shared RRF pool, and the body (matched by two providers) ranked top. MMR is what discarded it.

**Fix**: seed MMR with the single most-relevant candidate even when it alone exceeds the budget; downstream `applyBudgetAndLimit` truncates it to fit. Lower-relevance oversized candidates are still dropped, so `respects token budget` still holds.

Test: `the most relevant candidate survives even when it alone exceeds the budget` — verified failing before the fix (BUILD FAILED), passing after.

**Acceptance**: `query_context("process_load_confirmation_main")` now keeps the body as the top hit with `provider=symbol/full_text` sources. Query-time — no reindex; rebuild JAR + restart. (Pre-existing FTS git-snippet test fails in the sandbox, unrelated — verified by reverting.)
🤖 Generated with [Claude Code](https://claude.com/claude-code)