### PR TITLE
search: rank exact-identifier matches above fuzzy semantic hits

### DIFF
--- a/src/main/kotlin/com/orchestrator/mcp/tools/QueryContextTool.kt
+++ b/src/main/kotlin/com/orchestrator/mcp/tools/QueryContextTool.kt
@@ -249,8 +249,16 @@ class QueryContextTool(
         // Apply path/language boosts, then push forward declarations below real definitions.
         val boostedSnippets = deRankForwardDeclarations(applyScoreBoosts(pathFiltered))
 
+        // For a bare-identifier query (e.g. `process_load_confirmation_main`), an exact structured
+        // match — the symbol provider matched the name, or full-text matched the literal token — is
+        // the definition the caller wants. RRF weighting otherwise lets a high-weight fuzzy *semantic*
+        // neighbour outrank it (symbol+full_text weight < semantic weight), so the real definition
+        // sinks below the budget cut and never reaches the output. Lift exact matches into a reserved
+        // top band so they always outrank semantic-only hits, preserving their internal order.
+        val exactRanked = boostExactIdentifierMatches(boostedSnippets, originalQuery)
+
         // Filter by minimum score threshold from config
-        val filteredSnippets = boostedSnippets.filter { it.score >= config.query.minScoreThreshold }
+        val filteredSnippets = exactRanked.filter { it.score >= config.query.minScoreThreshold }
         if (filteredSnippets.size < boostedSnippets.size) {
             log.debug("Filtered {} snippets below min_score_threshold of {}",
                 boostedSnippets.size - filteredSnippets.size,
@@ -805,6 +813,39 @@ class QueryContextTool(
             !beginKeywordRegex.containsMatchIn(t) // a real body has BEGIN; a forward declaration does not
     }
 
+    /**
+     * When the query is a single identifier, an exact structured match (symbol-name hit, or full-text
+     * hit containing the literal identifier as a whole word) is the definition the user is after. RRF
+     * provider weighting can otherwise let a fuzzy semantic neighbour outrank it. Re-score so every
+     * exact match lands in the top half [0.5, 1.0] and every non-exact hit in [0.0, 0.5), keeping each
+     * group's internal order. No-op for multi-word/phrase queries.
+     */
+    private fun boostExactIdentifierMatches(snippets: List<ContextSnippet>, query: String): List<ContextSnippet> {
+        if (snippets.isEmpty()) return snippets
+        val identifier = query.trim()
+        if (identifier.length < MIN_IDENTIFIER_LEN || !IDENTIFIER_REGEX.matches(identifier)) return snippets
+
+        val wholeWord = Regex(
+            "(^|[^A-Za-z0-9_])" + Regex.escape(identifier) + "($|[^A-Za-z0-9_])",
+            RegexOption.IGNORE_CASE
+        )
+        fun isExactMatch(s: ContextSnippet): Boolean {
+            val sources = s.metadata["sources"]?.lowercase().orEmpty()
+            // The symbol provider matches by name/qualified-name, so its presence is a structured hit.
+            if ("symbol" in sources) return true
+            // A full-text/exact hit counts only if the literal identifier really appears in the body.
+            if (("full_text" in sources || "exact_match" in sources) && wholeWord.containsMatchIn(s.text)) return true
+            return false
+        }
+
+        val (exact, others) = snippets.partition { isExactMatch(it) }
+        if (exact.isEmpty()) return snippets // nothing to lift; leave ordering untouched
+
+        val rescaledExact = exact.map { it.copy(score = (0.5 + 0.5 * it.score.coerceIn(0.0, 1.0))) }
+        val rescaledOthers = others.map { it.copy(score = (0.5 * it.score.coerceIn(0.0, 1.0))) }
+        return (rescaledExact + rescaledOthers).sortedByDescending { it.score }
+    }
+
     private fun applyScoreBoosts(snippets: List<ContextSnippet>): List<ContextSnippet> {
         if (snippets.isEmpty()) return emptyList()
         if (config.query.boosts.pathPrefixes.isEmpty() && config.query.boosts.languages.isEmpty()) {
@@ -1102,6 +1143,11 @@ class QueryContextTool(
 
         // Forward declarations are demoted but not removed (kept as a fallback if no body exists).
         private const val FORWARD_DECL_PENALTY = 0.5
+
+        // A bare identifier of at least this length triggers the exact-match boost (avoids firing on
+        // trivial 1-2 char tokens). The query must be a single identifier with no other words.
+        private const val MIN_IDENTIFIER_LEN = 3
+        private val IDENTIFIER_REGEX = Regex("[A-Za-z_][A-Za-z0-9_]*")
         private val forwardDeclStartRegex = Regex(
             """^\s*(?:CREATE\s+(?:OR\s+REPLACE\s+)?)?(?:(?:MEMBER|STATIC|MAP|ORDER|FINAL|OVERRIDING|CONSTRUCTOR)\s+)*(?:PROCEDURE|FUNCTION)\b""",
             RegexOption.IGNORE_CASE

--- a/src/test/kotlin/com/orchestrator/mcp/tools/QueryContextToolTest.kt
+++ b/src/test/kotlin/com/orchestrator/mcp/tools/QueryContextToolTest.kt
@@ -8,6 +8,8 @@ import com.orchestrator.context.config.ProviderConfig
 import com.orchestrator.context.config.WatcherConfig
 import com.orchestrator.context.domain.Chunk
 import com.orchestrator.context.domain.ChunkKind
+import com.orchestrator.context.embedding.Embedder
+import com.orchestrator.context.providers.SemanticContextProvider
 import com.orchestrator.context.domain.FileState
 import com.orchestrator.context.storage.ChunkRepository
 import com.orchestrator.context.storage.ContextDatabase
@@ -444,6 +446,58 @@ class QueryContextToolTest {
         assertTrue(scoped.hits.any { it.filePath.endsWith("target.pkb") }, "the target package survives the exclusion")
     }
 
+    @Test
+    fun `exact-name symbol and full_text hits reach output and outrank semantic forward decls`() {
+        // Reproduces the user's round-10 report: semantic=2, symbol=1, full_text=1, but returnedHits=2
+        // and both returned are semantic forward declarations — the exact-name body never reaches hits.
+        // Make the semantic provider fire in-test with a deterministic 16-dim embedder.
+        val previous = SemanticContextProvider.globalEmbedder
+        SemanticContextProvider.globalEmbedder = object : Embedder {
+            override suspend fun embed(text: String) = FloatArray(16) { 0.1f }
+            override suspend fun embedBatch(texts: List<String>) = texts.map { FloatArray(16) { 0.1f } }
+            override fun getDimension() = 16
+            override fun getModel() = "test-model"
+        }
+        try {
+            // The target definition: exact name, has a BEGIN body, one HUGE chunk (~18k tokens like a
+            // 1600-line PL/SQL procedure). Found by symbol (exact name) and full_text (literal string),
+            // NOT by semantic (no embedding) — exactly the user's provider split.
+            val bodyPath = tempDir.resolve("pkg/target.pkb")
+            java.nio.file.Files.createDirectories(bodyPath.parent); java.nio.file.Files.writeString(bodyPath, "x")
+            val bodyFile = insertFileStateAbsolute("pkg/target.pkb", bodyPath.toString(), "plsql")
+            val hugeBody = "PROCEDURE process_load_confirmation_main IS\nBEGIN\n" +
+                "  do_work(x);\n".repeat(6000) + "END process_load_confirmation_main;"
+            insertChunkSized(700L, bodyFile, hugeBody, ChunkKind.SQL_STATEMENT, tokenEstimate = hugeBody.length / 4)
+            insertSymbol(7001L, bodyFile, 700L, "process_load_confirmation_main", "plsql")
+
+            // Decommissioned monolith: small chunks of differently-named code, reachable ONLY via
+            // semantic (no shared literal token with the query → full_text/symbol skip them). They are
+            // NOT forward declarations, so deRankForwardDeclarations does not demote them — the body
+            // must win on its own merit as an exact identifier match, not because rivals are penalized.
+            val specPath = tempDir.resolve("old/3pl.pks")
+            java.nio.file.Files.createDirectories(specPath.parent); java.nio.file.Files.writeString(specPath, "x")
+            val specFile = insertFileStateAbsolute("old/3pl.pks", specPath.toString(), "plsql")
+            insertChunkSized(710L, specFile, "result := transfers_helper(p_batch);", ChunkKind.CODE_BLOCK, tokenEstimate = 12)
+            insertChunkSized(711L, specFile, "result := adjustments_helper(p_batch);", ChunkKind.CODE_BLOCK, tokenEstimate = 12)
+            insertEmbedding(710L); insertEmbedding(711L)
+
+            val tool = QueryContextTool(config)
+            val result = tool.execute(QueryContextTool.Params(query = "process_load_confirmation_main"))
+
+            val hitFiles = result.hits.map { it.filePath to "%.3f".format(it.score) }
+            assertTrue(
+                result.hits.any { it.filePath.endsWith("target.pkb") },
+                "the exact-name body must reach hits, not be dropped after fusion. providers=${result.metadata["providers"]} hits=$hitFiles"
+            )
+            assertTrue(
+                result.hits.first().filePath.endsWith("target.pkb"),
+                "the exact-name body must be the TOP hit, above semantic forward decls. hits=$hitFiles"
+            )
+        } finally {
+            SemanticContextProvider.globalEmbedder = previous
+        }
+    }
+
     private fun insertSymbol(symbolId: Long, fileId: Long, chunkId: Long, name: String, language: String) {
         ContextDatabase.withConnection { conn ->
             conn.prepareStatement(
@@ -467,6 +521,23 @@ class QueryContextToolTest {
                 startLine = 1,
                 endLine = 10,
                 tokenEstimate = 50,
+                content = content,
+                summary = "summary",
+                createdAt = Instant.now()
+            )
+        )
+    }
+
+    private fun insertChunkSized(chunkId: Long, fileId: Long, content: String, kind: ChunkKind, tokenEstimate: Int) {
+        ChunkRepository.insert(
+            Chunk(
+                id = chunkId,
+                fileId = fileId,
+                ordinal = 0,
+                kind = kind,
+                startLine = 1,
+                endLine = 10,
+                tokenEstimate = tokenEstimate,
                 content = content,
                 summary = "summary",
                 createdAt = Instant.now()


### PR DESCRIPTION
**Round 10 — the fusion symptom, finally root-caused with an end-to-end reproduction.** `symbol` and `full_text` find `process_load_confirmation_main` (snippets=1 each), but the body never reaches `hits`: `returnedHits` are the semantic forward declarations and `totalHits − returnedHits == symbol + full_text` every time.

**Reproduced in `QueryContextToolTest`** (with a deterministic in-test embedder so the semantic provider fires against a temp DB). The drop is **RRF provider weighting**, not the fusion plumbing — and not MMR alone:

- `ReciprocalRankFusion.fuse` *does* merge symbol/full_text into the shared pool (the user's "fusion is semantic-only" was a symptom, not the mechanism).
- But with weights `semantic=0.6, symbol=0.3, full_text=0.1`, a fuzzy **semantic** neighbour scores `0.6/(k+1)` while the exact match scores `symbol+full_text = 0.4/(k+1)`. The exact-name body normalizes to ~0.67 of the top, sinks **below** the two semantic hits, and is then removed by the MMR budget pass (it's one huge ~18k-token chunk). Only semantic survives.
- `deRankForwardDeclarations` didn't rescue it — it only fires on `SQL_STATEMENT` forward-decl chunks, so semantic prose rivals keep full score.

**Fix**: for a bare-identifier query, lift exact structured matches (symbol-name hits, or full-text/exact hits containing the literal identifier as a whole word) into a reserved top band `[0.5, 1.0]` and push non-exact hits into `[0.0, 0.5)`, preserving each group's internal order. The definition then **seeds MMR** (kept even when oversized, per #58) and surfaces as the **top hit**. No-op for multi-word/phrase queries.

Builds on #57 (truncate oversized matches) and #58 (MMR keeps the oversized seed) — all three are needed for the exact-name body to surface. Query-time only; rebuild JAR + restart, no reindex.

Test: `exact-name symbol and full_text hits reach output and outrank semantic forward decls` — verified failing before the fix (BUILD FAILED), passing after. (Pre-existing FTS git-snippet test still fails in the sandbox, unrelated.)
🤖 Generated with [Claude Code](https://claude.com/claude-code)